### PR TITLE
Fix Beautiful Soup issue on Linux

### DIFF
--- a/third_party/tvcm/tvcm/parse_html_deps.py
+++ b/third_party/tvcm/tvcm/parse_html_deps.py
@@ -16,7 +16,7 @@ def _InitBeautifulSoup():
   bs_path = os.path.join(tvcm_path, 'third_party', 'beautifulsoup')
   if bs_path in sys.path:
     return
-  sys.path.append(bs_path)
+  sys.path.insert(0, bs_path)
 _InitBeautifulSoup()
 import BeautifulSoup
 


### PR DESCRIPTION
Some Linux distributions include BeautifulSoup 3.2.1, which exhibits a bug that causes text inside of script tags to be escaped. BeautifulSoup 3.2.0 is included with TVCM, and this change causes the path to the bundled version to be prepended rather than appended to sys.path so that it, rather than the broken system version, will be imported.
