### PR TITLE
Fix failing performace tests

### DIFF
--- a/trace_viewer/tracing/tracks/drawing_container_perf_test.html
+++ b/trace_viewer/tracing/tracks/drawing_container_perf_test.html
@@ -44,7 +44,7 @@ tvcm.unittest.testSuite(function() {  // @suppress longLineCheck
       setUpOnce();
       viewportDiv = document.createElement('div');
 
-      if (this.name === 'drawTrackContents_softwareCanvas') {
+      if (this.name === 'draw_softwareCanvas') {
         viewportDiv.width = '200px';
         viewportDiv.style.width = '200px';
       }
@@ -92,9 +92,9 @@ tvcm.unittest.testSuite(function() {  // @suppress longLineCheck
   var n110100 = [1, 10, 100];
   n110100.forEach(function(val) {
     timedDrawingContainerPerfTest(
-        'drawTrackContents_softwareCanvas_' + val,
+        'draw_softwareCanvas_' + val,
         function() {
-          drawingContainer.drawTrackContents_();
+          drawingContainer.draw_();
         }, val);
   });
 });


### PR DESCRIPTION
Track contents drawing function is draw_() instead of drawTrackContents_().

Call to invalid function drawTrackContents_() is causing failure of performance tests:
tracing.tracks.drawing_container_perf_test.draw_softwareCanvas_1
tracing.tracks.drawing_container_perf_test.draw_softwareCanvas_10
tracing.tracks.drawing_container_perf_test.draw_softwareCanvas_100

drawTrackContents_() was renamed to draw_() as part of revision 1544 - Add collapsing to most tracks in the timeline

[1] https://code.google.com/p/trace-viewer/source/diff?spec=svn1544&r=1544&format=side&path=/trunk/trace_viewer/tracing/tracks/drawing_container.html

R=dsinclair@chromium.org
