### PR TITLE
Scrollbar not working in timing mode

### DIFF
--- a/trace_viewer/tracing/timing_tool.html
+++ b/trace_viewer/tracing/timing_tool.html
@@ -46,6 +46,9 @@ tvcm.exportTo('tracing', function() {
     },
 
     onBeginTiming: function(e) {
+      if (!this.isTouchPointInsideTrackBounds_(e.clientX, e.clientY))
+        return;
+
       var pt = this.getSnappedToEventPosition_(e);
       this.mouseDownAt_(pt.x, pt.y);
 
@@ -90,6 +93,20 @@ tvcm.exportTo('tracing', function() {
     },
 
     ////////////////////////////////////////////////////////////////////////////
+
+    isTouchPointInsideTrackBounds_: function (clientX, clientY) {
+      if (!this.viewport_ ||
+          !this.viewport_.modelTrackContainer ||
+          !this.viewport_.modelTrackContainer.canvas)
+        return false;
+
+      var canvasRect = this.viewport_.modelTrackContainer.canvas.getBoundingClientRect();
+      if (clientX >= canvasRect.left && clientX <= canvasRect.right &&
+          clientY >= canvasRect.top && clientY <= canvasRect.bottom)
+        return true;
+
+      return false;
+    },
 
     mouseDownAt_: function(worldX, y) {
       var ir = this.viewport_.interestRange;


### PR DESCRIPTION
On clicking scroll bar of 'timing mode', thread times window is shifting to
right side and user is unable to scroll down. We are assuming that every hit
in timing mode is on the canvas area itself and moving to setting the interest
range value including that the range right is being selected. Do the interest
range actions only if the mousedown hit point is in the canvas rect.

BUG=549
