### PR TITLE
 Subtrace data not handled by any importer should be ignored.

### DIFF
--- a/trace_viewer/tracing/importer/gzip_importer.html
+++ b/trace_viewer/tracing/importer/gzip_importer.html
@@ -122,6 +122,14 @@ tvcm.exportTo('tracing.importer', function() {
     __proto__: Importer.prototype,
 
     /**
+     * Called by the Model to check whether the importer just encapsulates
+     * the actual trace data which needs to be imported by another importer.
+     */
+    isTraceDataContainer: function() {
+      return true;
+    },
+
+    /**
      * Called by the Model to extract subtraces from the event data. The
      * subtraces are passed on to other importers that can recognize them.
      */

--- a/trace_viewer/tracing/importer/importer.html
+++ b/trace_viewer/tracing/importer/importer.html
@@ -18,6 +18,14 @@ tvcm.exportTo('tracing.importer', function() {
     __proto__: Object.prototype,
 
     /**
+     * Called by the Model to check whether the importer type stores the actual
+     * trace data or just holds it as container for further extraction.
+     */
+    isTraceDataContainer: function() {
+      return false;
+    },
+
+    /**
      * Called by the Model to extract one or more subtraces from the event data.
      */
     extractSubtraces: function() {

--- a/trace_viewer/tracing/importer/trace2html_importer.html
+++ b/trace_viewer/tracing/importer/trace2html_importer.html
@@ -65,6 +65,10 @@ tvcm.exportTo('tracing.importer', function() {
   Trace2HTMLImporter.prototype = {
     __proto__: tracing.importer.Importer.prototype,
 
+    isTraceDataContainer: function() {
+      return true;
+    },
+
     extractSubtraces: function() {
       return _extractEventsFromHTML(this.events_, true).subtraces;
     },

--- a/trace_viewer/tracing/importer/zip_importer.html
+++ b/trace_viewer/tracing/importer/zip_importer.html
@@ -45,6 +45,10 @@ tvcm.exportTo('tracing.importer', function() {
   ZipImporter.prototype = {
     __proto__: Importer.prototype,
 
+    isTraceDataContainer: function() {
+      return true;
+    },
+
     extractSubtraces: function() {
       var zip = new JSZip(this.eventData_);
       var subtraces = [];

--- a/trace_viewer/tracing/trace_model.html
+++ b/trace_viewer/tracing/trace_model.html
@@ -236,6 +236,7 @@ tvcm.exportTo('tracing', function() {
           break;
         }
       }
+      // TODO(kphanee): Throwing same Error at 2 places. Lets try to avoid it!
       if (!importerConstructor)
         throw new Error(
             'Could not find an importer for the provided eventData.');
@@ -318,6 +319,17 @@ tvcm.exportTo('tracing', function() {
       return promise;
     },
 
+    hasEventDataDecoder_: function(importers) {
+      if (importers.length === 0)
+        return false;
+
+      for (var i = 0; i < importers.length; ++i) {
+        if (!importers[i].isTraceDataContainer())
+          return true;
+      }
+      return false;
+    },
+
     /**
      * Creates a task that will import the provided traces into the model,
      * updating the progressMeter as it goes. Parameters are as defined in
@@ -360,10 +372,19 @@ tvcm.exportTo('tracing', function() {
         for (var i = 0; i < importers.length; i++) {
           var subtraces = importers[i].extractSubtraces();
           for (var j = 0; j < subtraces.length; j++) {
-            traces.push(subtraces[j]);
-            importers.push(this.createImporter_(subtraces[j]));
+            try {
+              traces.push(subtraces[j]);
+              importers.push(this.createImporter_(subtraces[j]));
+            } catch (error) {
+              // TODO(kphanee): Log the subtrace file which has failed.
+              console.warn(error.name + ': ' + error.message);
+              continue;
+            }
           }
         }
+
+        if (traces.length && !this.hasEventDataDecoder_(importers))
+          throw new Error('Could not find an importer for the provided eventData.');
 
         // Sort them on priority. This ensures importing happens in a
         // predictable order, e.g. linux_perf_importer before


### PR DESCRIPTION
When importing zip, gzip traces, the archive might contain eventData
which is neither json nor empty string. Trace-viewer doesn't know
how to handle that eventData and it throws no importer error.

Any eventData which is not json, should be treated as empty string
and should be handled by TraceModelEmptyImporter itself.

BUG= #613 
