### PR TITLE
Making sure temporary named file is created with 'w' mode.

### DIFF
--- a/trace_viewer/build/trace2html.py
+++ b/trace_viewer/build/trace2html.py
@@ -53,7 +53,7 @@ class ViewerDataScript(generate.ExtraScript):
   def WriteToFile(self, output_file):
     output_file.write('<script id="viewer-data" type="application/json">\n')
 
-    with tempfile.NamedTemporaryFile() as compressed_file:
+    with tempfile.NamedTemporaryFile('w') as compressed_file:
       gzfile = gzip.open(compressed_file.name, 'wb')
       with open(self._filename, 'r') as f:
         shutil.copyfileobj(f, gzfile)


### PR DESCRIPTION
Currently, this causes permission error on Windows platform
