### PR TITLE
Use fixed margins for counter track series spanning the whole viewport

### DIFF
--- a/trace_viewer/tracing/tracks/counter_track.html
+++ b/trace_viewer/tracing/tracks/counter_track.html
@@ -75,7 +75,7 @@ tvcm.exportTo('tracing.tracks', function() {
       var skipDistanceWorld = dt.xViewVectorToWorld(skipDistancePix);
 
       // Width of the viewport.
-      var viewWWorld = viewRWorld - viewRWorld;
+      var viewWWorld = viewRWorld - viewLWorld;
 
       // Begin rendering in world space.
       ctx.save();


### PR DESCRIPTION
An improvement for #625. When a counter track series spans the whole viewport (and overflows it), we only render the series within the viewport and add fixed margins on both sides of it. This reduces the resolution at which (full) clipping occurs roughly from 0.005 ms to 10^-8 ms.
