### PR TITLE
Visually redesigned the counter track class

### DIFF
--- a/trace_viewer/tracing/color_scheme.html
+++ b/trace_viewer/tracing/color_scheme.html
@@ -70,10 +70,13 @@ tv.exportTo('tracing', function() {
       return palette[colorId];
     },
 
-    getCounterSeriesColor: function(colorId, selectionState) {
+    getCounterSeriesColor: function(colorId, selectionState,
+                                    opt_alphaMultiplier) {
+      var event = {selectionState: selectionState};
       return tv.ui.colorToRGBAString(
-          paletteRaw[colorId],
-          this.getAlpha_({selectionState: selectionState}));
+          paletteRaw[colorId + this.getColorIdOffset_(event)],
+          this.getAlpha_(event) *
+              (opt_alphaMultiplier !== undefined ? opt_alphaMultiplier : 1.0));
     },
 
     getBarSnapshotColor: function(snapshot, offset) {

--- a/trace_viewer/tracing/tracks/counter_track.html
+++ b/trace_viewer/tracing/tracks/counter_track.html
@@ -20,7 +20,15 @@ tv.exportTo('tracing.tracks', function() {
   var SelectionState = tracing.trace_model.SelectionState;
   var EventPresenter = tracing.EventPresenter;
   var LAST_SAMPLE_PIXELS = 8;
-  var VIEWPORT_RELATIVE_MARGIN = 10000;
+
+  var LINE_WIDTH = 1;
+  var BACKGROUND_ALPHA_MULTIPLIER = 0.5;
+  var SQUARE_WIDTH = 3; // Unselected sample point.
+  var CIRCLE_RADIUS = 2; // Selected sample point.
+
+  var POINT_DENSITY_TRANSPARENT = 0.10;
+  var POINT_DENSITY_OPAQUE = 0.05;
+  var POINT_DENSITY_RANGE = POINT_DENSITY_TRANSPARENT - POINT_DENSITY_OPAQUE;
 
   /**
    * A track that displays a Counter object.
@@ -70,16 +78,9 @@ tv.exportTo('tracing.tracks', function() {
       var dt = vp.currentDisplayTransform;
       var pixWidth = dt.xViewVectorToWorld(1);
 
-      // Drop sampels that are less than skipDistancePix apart.
+      // Drop samples that are less than skipDistancePix apart.
       var skipDistancePix = 1;
       var skipDistanceWorld = dt.xViewVectorToWorld(skipDistancePix);
-
-      // Width of the viewport.
-      var viewWWorld = viewRWorld - viewLWorld;
-
-      // Begin rendering in world space.
-      ctx.save();
-      dt.applyTransformToCanvas(ctx);
 
       // Figure out where drawing should begin.
       var numSeries = counter.numSeries;
@@ -93,117 +94,170 @@ tv.exportTo('tracing.tracks', function() {
       startIndex = startIndex - 1 > 0 ? startIndex - 1 : 0;
       // Draw indices one by one until we fall off the viewRWorld.
       var yScale = height / counter.maxTotal;
+
       for (var seriesIndex = counter.numSeries - 1;
            seriesIndex >= 0; seriesIndex--) {
         var series = counter.series[seriesIndex];
+        ctx.strokeStyle = EventPresenter.getCounterSeriesColor(
+            series.color, SelectionState.NONE);
 
-        // For performance reasons we only check the SelectionState of the first
-        // sample. If it's DIMMED we assume that the whole series is DIMMED.
-        // TODO(egraether): Allow partial highlight.
-        var selectionState = SelectionState.NONE;
-        if (series.samples.length &&
-            series.samples[0].selectionState === SelectionState.DIMMED) {
-          selectionState = SelectionState.DIMMED;
-        }
+        // Draw the background and the line.
+        var drawSeries = function(background) {
+          var selectionStateLast = -1;
 
-        ctx.fillStyle = EventPresenter.getCounterSeriesColor(
-            series.color, selectionState);
-        ctx.beginPath();
+          // Set i and x such that the first sample we draw is the
+          // startIndex sample.
+          var i = startIndex - 1;
+          var xLast = i >= 0 ?
+              timestamps[i] - skipDistanceWorld : -1;
+          var yLastView = height;
 
-        // Set iLast and xLast such that the first sample we draw is the
-        // startIndex sample.
-        var iLast = startIndex - 1;
-        var xLast = iLast >= 0 ?
-            timestamps[iLast] - skipDistanceWorld : -1;
-        var yLastView = height;
+          // Iterate over samples from i onward until we either fall off the
+          // viewRWorld or we run out of samples. To avoid drawing too much,
+          // after drawing a sample at xLast, skip subsequent samples that are
+          // less than skipDistanceWorld from xLast.
+          var hasMoved = false;
 
-        // Iterate over samples from iLast onward until we either fall off the
-        // viewRWorld or we run out of samples. To avoid drawing too much, after
-        // drawing a sample at xLast, skip subsequent samples that are less than
-        // skipDistanceWorld from xLast.
-        var hasMoved = false;
+          while (true) {
+            i++;
+            if (i >= numSamples) {
+              break;
+            }
 
-        while (true) {
-          var i = iLast + 1;
-          if (i >= numSamples) {
-            ctx.lineTo(xLast, yLastView);
-            ctx.lineTo(xLast + LAST_SAMPLE_PIXELS * pixWidth, yLastView);
-            ctx.lineTo(xLast + LAST_SAMPLE_PIXELS * pixWidth, height);
-            break;
+            var x = timestamps[i];
+            var y = counter.totals[i * numSeries + seriesIndex];
+            var yView = height - (yScale * y);
+
+            // If the sample is to the right of the viewport, we add a fixed
+            // margin to reduce zooming clipping errors.
+            if (x > viewRWorld) {
+              if (hasMoved) {
+                xLast = x = viewRWorld;
+                ctx.lineTo(dt.xWorldToView(x), yLastView);
+              }
+              break;
+            }
+
+            if (i + 1 < numSamples) {
+              var xNext = timestamps[i + 1];
+              if (xNext - xLast <= skipDistanceWorld && xNext < viewRWorld) {
+                continue;
+              }
+
+              // If the sample is to the left of the viewport, we add a fixed
+              // margin to reduce zooming clipping errors.
+              if (x < viewLWorld) {
+                x = viewLWorld;
+              }
+            }
+
+            if (x - xLast < skipDistanceWorld && xLast < x) {
+              // We know that xNext > xLast + skipDistanceWorld, so we can
+              // safely move this sample's x over that much without passing
+              // xNext.  This ensure that the previous sample is visible when
+              // zoomed out very far.
+              x = xLast + skipDistanceWorld;
+            }
+
+            var selectionState = series.samples[i].selectionState;
+
+            if (hasMoved) {
+              ctx.lineTo(dt.xWorldToView(x), yLastView);
+              if (selectionState != selectionStateLast) {
+                if (background) {
+                  ctx.lineTo(dt.xWorldToView(x), height);
+                  ctx.closePath();
+                  ctx.fill();
+                } else {
+                  ctx.lineTo(dt.xWorldToView(x), yView);
+                  ctx.stroke();
+                }
+              }
+            }
+
+            if (selectionState != selectionStateLast) {
+              ctx.fillStyle = EventPresenter.getCounterSeriesColor(
+                  series.color, selectionState, BACKGROUND_ALPHA_MULTIPLIER);
+              ctx.lineWidth = LINE_WIDTH * pixelRatio;
+              ctx.beginPath();
+
+              if (background) {
+                ctx.moveTo(dt.xWorldToView(x), height);
+              } else {
+                ctx.moveTo(dt.xWorldToView(x), hasMoved ? yLastView : yView);
+              }
+            }
+
+            if (background) {
+                ctx.lineTo(dt.xWorldToView(x), yView);
+            } else {
+                ctx.lineTo(dt.xWorldToView(x), yView);
+            }
+
+            hasMoved = true;
+            xLast = x;
+            yLastView = yView;
+            selectionStateLast = selectionState;
           }
 
+          if (hasMoved) {
+            if (background) {
+              ctx.lineTo(dt.xWorldToView(xLast), height);
+              ctx.closePath();
+              ctx.fill();
+            } else {
+              ctx.stroke();
+            }
+          }
+        }
+
+        drawSeries(true);
+        drawSeries(false);
+
+        // Calculate point density and, consequently, opacity of sample points.
+        var endIndex = tv.findLowIndexInSortedArray(
+            counter.timestamps, function(x) { return x; }, viewRWorld);
+        if (counter.timestamps[endIndex] == viewRWorld) {
+          endIndex++;
+        }
+        var minVisible = (startIndex >= counter.timestamps.length ?
+                          viewLWorld : counter.timestamps[startIndex]);
+        var maxVisible = (endIndex < 1 ?
+                          viewRWorld : counter.timestamps[endIndex - 1]);
+        var rangeVisible = (minVisible >= maxVisible ?
+                            viewRWorld - viewLWorld : maxVisible - minVisible);
+
+        var density = (endIndex - startIndex) / (dt.scaleX * rangeVisible);
+        var clampedDensity = tv.clamp(density, POINT_DENSITY_OPAQUE,
+                                      POINT_DENSITY_TRANSPARENT);
+        var opacity =
+            (POINT_DENSITY_TRANSPARENT - clampedDensity) / POINT_DENSITY_RANGE;
+
+        // Draw sample points.
+        ctx.strokeStyle = EventPresenter.getCounterSeriesColor(
+            series.color, SelectionState.NONE);
+        for (var i = startIndex; timestamps[i] < viewRWorld; i++) {
           var x = timestamps[i];
           var y = counter.totals[i * numSeries + seriesIndex];
           var yView = height - (yScale * y);
 
-          // If the sample is to the right of the viewport, we add a fixed
-          // margin to reduce zooming clipping errors.
-          if (x > viewRWorld) {
-            ctx.lineTo(viewRWorld + VIEWPORT_RELATIVE_MARGIN * viewWWorld,
-                yLastView);
-            ctx.lineTo(viewRWorld + VIEWPORT_RELATIVE_MARGIN * viewWWorld,
-                height);
-            break;
-          }
-
-          if (i + 1 < numSamples) {
-            var xNext = timestamps[i + 1];
-            if (xNext - xLast <= skipDistanceWorld && xNext < viewRWorld ||
-                xNext < viewLWorld) {
-              iLast = i;
-              continue;
-            }
-          }
-
-          if (x - xLast < skipDistanceWorld) {
-            // We know that xNext > xLast + skipDistanceWorld, so we can
-            // safely move this sample's x over that much without passing
-            // xNext.  This ensure that the previous sample is visible when
-            // zoomed out very far.
-            x = xLast + skipDistanceWorld;
-          }
-
-          // If the sample is to the left of the viewport, we add a fixed
-          // margin to reduce zooming clipping errors.
-          if (x < viewLWorld) {
-            x = viewLWorld - VIEWPORT_RELATIVE_MARGIN * viewWWorld;
-          }
-
-          if (!hasMoved) {
-            ctx.moveTo(viewLWorld, yLastView);
-            hasMoved = true;
+          if (series.samples[i].selected) {
+            ctx.fillStyle = EventPresenter.getCounterSeriesColor(
+              series.color, series.samples[i].selectionState);
+            ctx.beginPath();
+            ctx.arc(dt.xWorldToView(x), yView, CIRCLE_RADIUS * pixelRatio, 0,
+                    2 * Math.PI);
+            ctx.fill();
+            ctx.stroke();
           } else {
-            ctx.lineTo(x, yLastView);
-          }
-          ctx.lineTo(x, yView);
-
-          iLast = i;
-          xLast = x;
-          yLastView = yView;
-        }
-        ctx.closePath();
-        ctx.fill();
-
-      }
-
-      ctx.fillStyle = 'rgba(255, 0, 0, 1)';
-      for (var seriesIndex = counter.numSeries - 1;
-           seriesIndex >= 0; seriesIndex--) {
-        var series = counter.series[seriesIndex];
-        var seriesSamples = series.samples;
-        for (var i = startIndex; timestamps[i] < viewRWorld; i++) {
-          if (!seriesSamples[i].selected)
-            continue;
-          var x = timestamps[i];
-          for (var seriesIndex = counter.numSeries - 1;
-               seriesIndex >= 0; seriesIndex--) {
-            var y = counter.totals[i * numSeries + seriesIndex];
-            var yView = height - (yScale * y);
-            ctx.fillRect(x - pixWidth, yView - 1, 3 * pixWidth, 3);
+            ctx.fillStyle = EventPresenter.getCounterSeriesColor(
+                series.color, series.samples[i].selectionState, opacity);
+            ctx.fillRect(dt.xWorldToView(x) - (SQUARE_WIDTH / 2) * pixelRatio,
+                         yView - (SQUARE_WIDTH / 2) * pixelRatio,
+                         SQUARE_WIDTH * pixelRatio, SQUARE_WIDTH * pixelRatio);
           }
         }
       }
-      ctx.restore();
     },
 
     addEventsToTrackMap: function(eventToTrackMap) {


### PR DESCRIPTION
This patch improves the visual design of the counter track class. Rather than being displayed as a sequence of simple blocks, it looks like a line plot now:
![line_counter](https://cloud.githubusercontent.com/assets/2546601/4560559/f9b85c08-4ef5-11e4-8096-d20ded2f1e3f.png)
Note that this change completely fixes #625 (for counter tracks) as we draw the plot manually in view coordinates (to ensure constant line width) and thereby avoid using canvas transforms.
