### PR TITLE
Show annotated invalidation rects in FrameViewer

### DIFF
--- a/trace_viewer/cc/layer_impl.html
+++ b/trace_viewer/cc/layer_impl.html
@@ -38,6 +38,7 @@ tv.exportTo('cc', function() {
     initialize: function() {
       // Defaults.
       this.invalidation = new cc.Region();
+      this.annotatedInvalidation = new cc.Region();
       this.unrecordedRegion = new cc.Region();
       this.pictures = [];
 
@@ -124,6 +125,16 @@ tv.exportTo('cc', function() {
       if (this.args.invalidation) {
         this.invalidation = cc.Region.fromArray(this.args.invalidation);
         delete this.args.invalidation;
+      }
+      if (this.args.annotatedInvalidationRects) {
+        this.annotatedInvalidation = new cc.Region();
+        for (var i = 0; i < this.args.annotatedInvalidationRects.length; ++i) {
+          var annotatedRect = this.args.annotatedInvalidationRects[i];
+          var rect = annotatedRect.geometryRect;
+          rect.reason = annotatedRect.reason;
+          this.annotatedInvalidation.addRect(rect);
+        }
+        delete this.args.annotatedInvalidationRects;
       }
       if (this.args.unrecordedRegion) {
         this.unrecordedRegion = cc.Region.fromArray(

--- a/trace_viewer/cc/layer_tree_quad_stack_view.html
+++ b/trace_viewer/cc/layer_tree_quad_stack_view.html
@@ -702,16 +702,34 @@ tv.exportTo('cc', function() {
         return;
 
       // Generate the invalidation rect quads.
-      for (var ir = 0; ir < layer.invalidation.rects.length; ir++) {
-        var rect = layer.invalidation.rects[ir];
+      for (var ir = 0; ir < layer.annotatedInvalidation.rects.length; ir++) {
+        var rect = layer.annotatedInvalidation.rects[ir];
         var unitRect = rect.asUVRectInside(layer.bounds);
         var iq = layerQuad.projectUnitRect(unitRect);
         iq.backgroundColor = 'rgba(0, 255, 0, 0.1)';
+        if (rect.reason === 'renderer insertion')
+            iq.backgroundColor = 'rgba(0, 255, 128, 0.1)';
         iq.borderColor = 'rgba(0, 255, 0, 1)';
         iq.stackingGroupId = layerQuad.stackingGroupId;
         iq.selectionToSetIfClicked = new cc.LayerRectSelection(
-            layer, 'Invalidation rect', rect, rect);
+            layer, 'Invalidation rect (' + rect.reason + ')', rect, rect);
         quads.push(iq);
+      }
+
+      // Show unannotated invalidation rect quads if no annotated rects are
+      // available.
+      if (layer.annotatedInvalidation.rects.length === 0) {
+        for (var ir = 0; ir < layer.invalidation.rects.length; ir++) {
+          var rect = layer.invalidation.rects[ir];
+          var unitRect = rect.asUVRectInside(layer.bounds);
+          var iq = layerQuad.projectUnitRect(unitRect);
+          iq.backgroundColor = 'rgba(0, 255, 0, 0.1)';
+          iq.borderColor = 'rgba(0, 255, 0, 1)';
+          iq.stackingGroupId = layerQuad.stackingGroupId;
+          iq.selectionToSetIfClicked = new cc.LayerRectSelection(
+              layer, 'Invalidation rect', rect, rect);
+          quads.push(iq);
+        }
       }
     },
 

--- a/trace_viewer/cc/region.html
+++ b/trace_viewer/cc/region.html
@@ -48,6 +48,10 @@ tv.exportTo('cc', function() {
           return true;
       }
       return false;
+    },
+
+    addRect: function(r) {
+      this.rects.push(r);
     }
   };
 


### PR DESCRIPTION
Migrating this from rietveld: https://codereview.appspot.com/142540045/

---

CL depends on Blink CL currently under review:
https://codereview.chromium.org/615223004/

This CL adds support for showing annotated invalidation rects from Blink
GraphicsLayerDebugInfo.
FrameViewer users can see Blink RenderObject paint invalidations, along
with its InvalidationReason.

BUG=402033
