### PR TITLE
Fix slice error problem in parsing nestable async events

### DIFF
--- a/trace_viewer/tracing/importer/trace_event_importer.html
+++ b/trace_viewer/tracing/importer/trace_event_importer.html
@@ -647,10 +647,10 @@ tv.exportTo('tracing.importer', function() {
               eventStateEntry.finished === undefined) {
             continue;
           }
-          var startState;
-          var endState;
-          var sliceArgs;
-          var sliceError;
+          var startState = undefined;
+          var endState = undefined;
+          var sliceArgs = undefined;
+          var sliceError = undefined;
           if (eventStateEntry.event.ph === 'n') {
             startState = eventStateEntry;
             endState = eventStateEntry;


### PR DESCRIPTION
@dj2  I didn't know that javascript can reuse variables. The bug is that when I populate sliceError variable, it does not get cleared in the following iterations of the for loop. To see the bug in action, go to http://localhost:8003/examples/trace_viewer.html#nestable_async.json, you will see REQUEST_FOO's children all have slice error, while only the first one is supposed to. I changed the code so that we explicitly declare the variables as undefined in each iteration.
