### PR TITLE
Fix overlapping slices

### DIFF
--- a/trace_viewer/tracing/tracks/async_slice_group_track.html
+++ b/trace_viewer/tracing/tracks/async_slice_group_track.html
@@ -64,6 +64,27 @@ tv.exportTo('tracing.tracks', function() {
         return x.start - y.start;
       });
 
+      // Helper function that returns true if it can put the slice on row n.
+      var findLevel = function(sliceToPut, rows, n) {
+        if (n >= rows.length)
+          return true; // We always can make empty rows to put the slice.
+        var subRow = rows[n];
+        var lastSliceInSubRow = subRow[subRow.length - 1];
+        if (sliceToPut.start >= lastSliceInSubRow.end) {
+          if (sliceToPut.subSlices === undefined ||
+              sliceToPut.subSlices.length === 0) {
+            return true;
+          }
+          // Make sure nested sub slices can be fitted in as well.
+          for (var i = 0; i < sliceToPut.subSlices.length; i++) {
+            if (!findLevel(sliceToPut.subSlices[i], rows, n + 1))
+              return false;
+          }
+          return true;
+        }
+        return false;
+      }
+
       var subRows = [];
       for (var i = 0; i < slices.length; i++) {
         var slice = slices[i];
@@ -71,9 +92,7 @@ tv.exportTo('tracing.tracks', function() {
         var found = false;
         var index = subRows.length;
         for (var j = 0; j < subRows.length; j++) {
-          var subRow = subRows[j];
-          var lastSliceInSubRow = subRow[subRow.length - 1];
-          if (slice.start >= lastSliceInSubRow.end) {
+          if (findLevel(slice, subRows, j)) {
             found = true;
             index = j;
             break;

--- a/trace_viewer/tracing/tracks/async_slice_group_track_test.html
+++ b/trace_viewer/tracing/tracks/async_slice_group_track_test.html
@@ -130,6 +130,76 @@ tv.unittest.testSuite(function() { // @suppress longLineCheck
     assertEquals(g.slices[1], subRows[1][0]);
     assertEquals(g.slices[2], subRows[0][1]);
   });
+
+  // Tests that no slices and their sub slices overlap.
+  test('rebuildSubRows_NonOverlappingSubSlices', function() {
+    var model = new tracing.TraceModel();
+    var p1 = new Process(model, 1);
+    var t1 = new Thread(p1, 1);
+    var g = new AsyncSliceGroup(t1);
+
+    var slice1 = newAsyncSlice(0, 5, t1, t1);
+    var slice1Child = newAsyncSlice(1, 2, t1, t1);
+    slice1.subSlices = [slice1Child];
+    var slice2 = newAsyncSlice(3, 5, t1, t1);
+    var slice3 = newAsyncSlice(5, 4, t1, t1);
+    var slice3Child = newAsyncSlice(6, 2, t1, t1);
+    slice3.subSlices = [slice3Child];
+    g.push(slice1);
+    g.push(slice2);
+    g.push(slice3);
+    g.updateBounds();
+
+    var track = new AsyncSliceGroupTrack(new tracing.TimelineViewport());
+    track.group = g;
+
+    var subRows = track.subRows;
+    // Checks each sub row to see that we don't have any overlapping slices.
+    for (var i = 0; i < subRows.length; i++) {
+      var row = subRows[i];
+      for (var j = 0; j < row.length; j++) {
+        for (var k = j + 1; k < row.length; k++) {
+          assertTrue(row[j].end <= row[k].start);
+        }
+      }
+    }
+  });
+
+  test('rebuildSubRows_NonOverlappingSubSlicesThreeNestedLevels', function() {
+    var model = new tracing.TraceModel();
+    var p1 = new Process(model, 1);
+    var t1 = new Thread(p1, 1);
+    var g = new AsyncSliceGroup(t1);
+
+    var slice1 = newAsyncSlice(0, 4, t1, t1);
+    var slice1Child = newAsyncSlice(1, 2, t1, t1);
+    slice1.subSlices = [slice1Child];
+    var slice2 = newAsyncSlice(2, 7, t1, t1);
+    var slice3 = newAsyncSlice(5, 5, t1, t1);
+    var slice3Child = newAsyncSlice(6, 3, t1, t1);
+    var slice3Child2 = newAsyncSlice(7, 1, t1, t1);
+    slice3.subSlices = [slice3Child];
+    slice3Child.subSlices = [slice3Child2];
+    g.push(slice1);
+    g.push(slice2);
+    g.push(slice3);
+    g.updateBounds();
+
+    var track = new AsyncSliceGroupTrack(new tracing.TimelineViewport());
+    track.group = g;
+
+    var subRows = track.subRows;
+    // Checks each sub row to see that we don't have any overlapping slices.
+    for (var i = 0; i < subRows.length; i++) {
+      var row = subRows[i];
+      for (var j = 0; j < row.length; j++) {
+        for (var k = j + 1; k < row.length; k++) {
+          assertTrue(row[j].end <= row[k].start);
+        }
+      }
+    }
+  });
+
 });
 </script>
 


### PR DESCRIPTION
This is a fix to issue #640. I overlooked the fact that sub slices can overlap other slices in my earlier code. The fix is to recursively check if sub slices can fit in the rows below the parent.
