### PR TITLE
use NetAsyncSlice for disabled-by-default-netlog category

### DIFF
--- a/trace_viewer/net/net_async_slice.html
+++ b/trace_viewer/net/net_async_slice.html
@@ -24,6 +24,7 @@ tv.exportTo('net', function() {
   };
 
   AsyncSlice.registerCategory('netlog', NetAsyncSlice);
+  AsyncSlice.registerCategory('disabled-by-default-netlog', NetAsyncSlice);
 
   return {
     NetAsyncSlice: NetAsyncSlice


### PR DESCRIPTION
Netlog events are now prefixed by "disabled-by-default-". We should use NetAsyncSlice constructor for this disabled category.
