### PR TITLE
Do not recompute the title of Net async slice if it is redrawn

### DIFF
--- a/trace_viewer/net/net_async_slice.html
+++ b/trace_viewer/net/net_async_slice.html
@@ -14,6 +14,8 @@ tv.exportTo('net', function() {
 
   function NetAsyncSlice() {
     AsyncSlice.apply(this, arguments);
+    // A boolean variable indicates whether we have computed the title.
+    this.isTitleComputed_ = false;
   }
 
   NetAsyncSlice.prototype = {
@@ -24,6 +26,10 @@ tv.exportTo('net', function() {
     },
 
     get title() {
+      if (this.isTitleComputed_ || !this.isTopLevel) {
+        return this.title_;
+      }
+
       // A recursive helper function that gets the url param of a slice or its
       // nested subslices if there is one.
       var getUrl = function(slice) {
@@ -41,11 +47,14 @@ tv.exportTo('net', function() {
         return undefined;
       };
 
-      if (this.isTopLevel === true) {
-        var url = getUrl(this);
-        if (url !== undefined && url.length > 0)
-          return url;
+      var url = getUrl(this);
+      if (url !== undefined && url.length > 0) {
+        // Set the title so we do not have to recompute when it is redrawn.
+        this.title_ = url;
+        this.isTitleComputed_ = true;
+        return url;
       }
+      this.isTitleComputed_ = true;
       return this.title_;
     },
 

--- a/trace_viewer/net/net_async_slice_test.html
+++ b/trace_viewer/net/net_async_slice_test.html
@@ -88,5 +88,25 @@ tv.unittest.testSuite(function() {
     assertEquals("b", childSlice1.title);
     assertEquals("c", childSlice2.title);
   });
+
+  test('ExposeURLDoNotComputeUrlTwice', function() {
+    var slice = new NetSlice('', 'a', 0, 1, {params: {}});
+    slice.isTopLevel = true;
+    var childSlice1 = new NetSlice('', 'b', 0, 1,
+                                   {params: {url: "http://test.url.net"}});
+    var childSlice2 = new NetSlice('', 'c', 0, 1);
+
+    slice.subSlices = [childSlice1, childSlice2];
+    // Parent should take its child's url param.
+    assertEquals("http://test.url.net", slice.title);
+    assertEquals("b", childSlice1.title);
+    assertEquals("c", childSlice2.title);
+    // Now if we change the url param of the child, the parent's title should
+    // remain the same. We do not recompute.
+    childSlice1.args.params.url = "example.com";
+    assertEquals("http://test.url.net", slice.title);
+    assertEquals("b", childSlice1.title);
+    assertEquals("c", childSlice2.title);
+  });
 });
 </script>


### PR DESCRIPTION
When I tried to zoom in and out on NetLog data, it gets janky. The problem is that on redraw, we recompute the title for each slice. This can be a very expensive operation. A fix is to remember that we have already computed the title, since the computed result must remain the same. 
