### PR TITLE
Use source type as the title for top level events

### DIFF
--- a/trace_viewer/net/net_async_slice.html
+++ b/trace_viewer/net/net_async_slice.html
@@ -51,8 +51,9 @@ tv.exportTo('net', function() {
       if (url !== undefined && url.length > 0) {
         // Set the title so we do not have to recompute when it is redrawn.
         this.title_ = url;
-        this.isTitleComputed_ = true;
-        return url;
+      } else if (this.args !== undefined && this.args.source_type !== undefined) {
+        // We do not have a URL, use the source type as the title.
+        this.title_ = this.args.source_type;
       }
       this.isTitleComputed_ = true;
       return this.title_;

--- a/trace_viewer/net/net_async_slice_test.html
+++ b/trace_viewer/net/net_async_slice_test.html
@@ -38,13 +38,14 @@ tv.unittest.testSuite(function() {
   });
 
   test('ExposeURLBasic', function() {
-    var slice = new NetSlice('', 'a', 0, 1, {params: {url: "https://google.com"}});
+    var slice = new NetSlice('', 'a', 0, 1, {params: {url: "https://google.com"},
+                                             source_type: "b"});
     slice.isTopLevel = true;
     assertEquals("https://google.com", slice.title);
   });
 
   test('ExposeURLNested', function() {
-    var slice = new NetSlice('', 'a', 0, 1, {params: {}});
+    var slice = new NetSlice('', 'a', 0, 1, {params: {}, source_type: "HELLO"});
     slice.isTopLevel = true;
     var childSlice = new NetSlice('', 'b', 0, 1, {params: {url: "http://test.url"}});
     slice.subSlices = [childSlice];
@@ -105,6 +106,19 @@ tv.unittest.testSuite(function() {
     // remain the same. We do not recompute.
     childSlice1.args.params.url = "example.com";
     assertEquals("http://test.url.net", slice.title);
+    assertEquals("b", childSlice1.title);
+    assertEquals("c", childSlice2.title);
+  });
+
+  test('ExposeSourceTypeAsTitle', function() {
+    var slice = new NetSlice('', 'a', 0, 1, {params: {}, source_type: "UDP_SOCKET"});
+    slice.isTopLevel = true;
+    var childSlice1 = new NetSlice('', 'b', 0, 1, {params: {}, source_type: "SOCKET"});
+    var childSlice2 = new NetSlice('', 'c', 0, 1);
+
+    slice.subSlices = [childSlice1, childSlice2];
+    // Parent should take its own source_type.
+    assertEquals("UDP_SOCKET", slice.title);
     assertEquals("b", childSlice1.title);
     assertEquals("c", childSlice2.title);
   });


### PR DESCRIPTION
This is to address issue #648. We would like to use source type as the title for top level events, as source type is more meaningful compared to the name of top level events.
