### PR TITLE
Don't show stale category entries in record selection dialog.

### DIFF
--- a/trace_viewer/about_tracing/record_selection_dialog.html
+++ b/trace_viewer/about_tracing/record_selection_dialog.html
@@ -450,11 +450,8 @@ tv.exportTo('about_tracing', function() {
       // Dedup the categories. We may have things in settings that are also
       // returned when we query the category list.
       var categorySet = {};
-      var allCategories =
-          this.categories_.concat(tv.Settings.keys(this.settings_key_));
-      var allCategoriesLength = allCategories.length;
-      for (var i = 0; i < allCategoriesLength; ++i)
-        categorySet[allCategories[i]] = true;
+      for (var i = 0; i < this.categories_.length; ++i)
+        categorySet[this.categories_[i]] = true;
       return categorySet;
     },
 


### PR DESCRIPTION
PTAL!

The idea of this CL is not to show any stale tracing categories in the record dialog.
Right now, we are adding the categories stored in local storage as well to the list actually received from the Tracer. But the categories stored in local storage might be stale and are no longer present in the tracer object.

I believe we should only use the tv.Settings.get/set for getting the stored value (whether it was selected or un-selected previously) and set the current state accordingly. It should not be appended to the list recieved from the tracer object. WDYT?

This is not a complete patch yet. Few test cases are failing with this change and I will update this CL with the updated test cases, if we are ok with the idea of this CL.
