### PR TITLE
Esc key action should be applied only to top level overlay.

### DIFF
--- a/trace_viewer/about_tracing/record_selection_dialog.html
+++ b/trace_viewer/about_tracing/record_selection_dialog.html
@@ -535,7 +535,8 @@ tv.exportTo('about_tracing', function() {
     createDefaultDisabledWarningDialog_: function(warningLink) {
       function onClickHandler(evt) {
         this.warningOverlay_ = tv.ui.Overlay();
-        this.warningOverlay_.title = 'Enabling Categories Warning...';
+        this.warningOverlay_.parentEl_ = this;
+        this.warningOverlay_.title = 'Warning...';
         this.warningOverlay_.userCanClose = true;
         this.warningOverlay_.visible = true;
 

--- a/trace_viewer/base/ui/overlay.html
+++ b/trace_viewer/base/ui/overlay.html
@@ -214,8 +214,8 @@ tv.exportTo('tv.ui', function() {
       this.parentEl_.appendChild(this);
 
       if (this.userCanClose_) {
-        document.addEventListener('keydown', this.onKeyDown_);
-        document.addEventListener('click', this.onDocumentClick_);
+        this.addEventListener('keydown', this.onKeyDown_.bind(this));
+        this.addEventListener('click', this.onDocumentClick_.bind(this));
       }
 
       this.parentEl_.addEventListener('focusin', this.onFocusIn_);
@@ -252,7 +252,8 @@ tv.exportTo('tv.ui', function() {
 
     onClose_: function(e) {
       this.visible = false;
-      if (e.type != 'keydown')
+      if ((e.type != 'keydown') ||
+          (e.type === 'keydown' && e.keyCode === 27))
         e.stopPropagation();
       e.preventDefault();
       tv.dispatchSimpleEvent(this, 'closeclick');


### PR DESCRIPTION
We shouldn't hide all the created overlays present in the stack on
the escape key action. Just like click Escape key action should be
applicable only to the overlay at the top of the stack.
