### PR TITLE
Add toplevel trace category in all preset record modes.

### DIFF
--- a/trace_viewer/about_tracing/record_selection_dialog.html
+++ b/trace_viewer/about_tracing/record_selection_dialog.html
@@ -163,15 +163,15 @@ tv.exportTo('about_tracing', function() {
 
   var DEFAULT_PRESETS = [
     {title: 'Web developer',
-      categoryFilter: ['blink', 'cc', 'net', 'v8']},
+      categoryFilter: ['blink', 'cc', 'net', 'toplevel', 'v8']},
     {title: 'Input latency',
-      categoryFilter: ['benchmark', 'input']},
+      categoryFilter: ['benchmark', 'input', 'toplevel']},
     {title: 'Rendering',
-      categoryFilter: ['blink', 'cc', 'gpu']},
+      categoryFilter: ['blink', 'cc', 'gpu', 'toplevel']},
     {title: 'Javascript and rendering',
-      categoryFilter: ['blink', 'cc', 'gpu', 'v8']},
+      categoryFilter: ['blink', 'cc', 'gpu', 'v8', 'toplevel']},
     {title: 'Frame Viewer',
-      categoryFilter: ['blink', 'cc', 'gpu', 'v8',
+      categoryFilter: ['blink', 'cc', 'gpu', 'v8', 'toplevel',
         'disabled-by-default-cc.debug']},
     {title: 'Manually select settings',
       categoryFilter: []}


### PR DESCRIPTION
Its important that we show people the distinction between idle
and doing-something-that-wasn't traced. To differentiate include
toplevel trace category in all preset modes.

BUG=607

R=nduca,dsinclair
