### PR TITLE
Add TrackVisitor class

### DIFF
--- a/trace_viewer/tracing/tracks/async_slice_group_track.html
+++ b/trace_viewer/tracing/tracks/async_slice_group_track.html
@@ -26,6 +26,8 @@ tv.exportTo('tracing.tracks', function() {
 
     __proto__: tracing.tracks.MultiRowTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'AsyncSliceGroupTrack',
+
     decorate: function(viewport) {
       tracing.tracks.MultiRowTrack.prototype.decorate.call(this, viewport);
       this.classList.add('async-slice-group-track');

--- a/trace_viewer/tracing/tracks/container_track.html
+++ b/trace_viewer/tracing/tracks/container_track.html
@@ -22,6 +22,8 @@ tv.exportTo('tracing.tracks', function() {
   ContainerTrack.prototype = {
     __proto__: tracing.tracks.Track.prototype,
 
+    TRACK_CLASS_NAME_: 'ContainerTrack',
+
     decorate: function(viewport) {
       tracing.tracks.Track.prototype.decorate.call(this, viewport);
     },

--- a/trace_viewer/tracing/tracks/counter_track.html
+++ b/trace_viewer/tracing/tracks/counter_track.html
@@ -42,6 +42,8 @@ tv.exportTo('tracing.tracks', function() {
   CounterTrack.prototype = {
     __proto__: tracing.tracks.HeadingTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'CounterTrack',
+
     decorate: function(viewport) {
       tracing.tracks.HeadingTrack.prototype.decorate.call(this, viewport);
       this.classList.add('counter-track');

--- a/trace_viewer/tracing/tracks/cpu_track.html
+++ b/trace_viewer/tracing/tracks/cpu_track.html
@@ -25,6 +25,8 @@ tv.exportTo('tracing.tracks', function() {
   CpuTrack.prototype = {
     __proto__: tracing.tracks.ContainerTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'CpuTrack',
+
     decorate: function(viewport) {
       tracing.tracks.ContainerTrack.prototype.decorate.call(this, viewport);
       this.classList.add('cpu-track');

--- a/trace_viewer/tracing/tracks/drawing_container.html
+++ b/trace_viewer/tracing/tracks/drawing_container.html
@@ -30,6 +30,8 @@ tv.exportTo('tracing.tracks', function() {
   DrawingContainer.prototype = {
     __proto__: tracing.tracks.Track.prototype,
 
+    TRACK_CLASS_NAME_: 'DrawingContainer',
+
     decorate: function(viewport) {
       tracing.tracks.Track.prototype.decorate.call(this, viewport);
       this.classList.add('drawing-container');

--- a/trace_viewer/tracing/tracks/heading_track.html
+++ b/trace_viewer/tracing/tracks/heading_track.html
@@ -30,6 +30,8 @@ tv.exportTo('tracing.tracks', function() {
   HeadingTrack.prototype = {
     __proto__: tracing.tracks.Track.prototype,
 
+    TRACK_CLASS_NAME_: 'HeadingTrack',
+
     decorate: function(viewport) {
       tracing.tracks.Track.prototype.decorate.call(this, viewport);
       this.classList.add('heading-track');

--- a/trace_viewer/tracing/tracks/kernel_track.html
+++ b/trace_viewer/tracing/tracks/kernel_track.html
@@ -26,6 +26,8 @@ tv.exportTo('tracing.tracks', function() {
   KernelTrack.prototype = {
     __proto__: ProcessTrackBase.prototype,
 
+    TRACK_CLASS_NAME_: 'KernelTrack',
+
     decorate: function(viewport) {
       tracing.tracks.ProcessTrackBase.prototype.decorate.call(this, viewport);
     },

--- a/trace_viewer/tracing/tracks/multi_row_track.html
+++ b/trace_viewer/tracing/tracks/multi_row_track.html
@@ -28,6 +28,8 @@ tv.exportTo('tracing.tracks', function() {
 
     __proto__: tracing.tracks.ContainerTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'MultiRowTrack',
+
     decorate: function(viewport) {
       tracing.tracks.ContainerTrack.prototype.decorate.call(this, viewport);
       this.tooltip_ = '';

--- a/trace_viewer/tracing/tracks/object_instance_group_track.html
+++ b/trace_viewer/tracing/tracks/object_instance_group_track.html
@@ -27,6 +27,8 @@ tv.exportTo('tracing.tracks', function() {
 
     __proto__: tracing.tracks.MultiRowTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'ObjectInstanceGroupTrack',
+
     decorate: function(viewport) {
       tracing.tracks.MultiRowTrack.prototype.decorate.call(this, viewport);
       this.classList.add('object-instance-group-track');

--- a/trace_viewer/tracing/tracks/object_instance_track.html
+++ b/trace_viewer/tracing/tracks/object_instance_track.html
@@ -33,6 +33,8 @@ tv.exportTo('tracing.tracks', function() {
   ObjectInstanceTrack.prototype = {
     __proto__: tracing.tracks.HeadingTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'ObjectInstanceTrack',
+
     decorate: function(viewport) {
       tracing.tracks.HeadingTrack.prototype.decorate.call(this, viewport);
       this.classList.add('object-instance-track');

--- a/trace_viewer/tracing/tracks/process_track.html
+++ b/trace_viewer/tracing/tracks/process_track.html
@@ -22,6 +22,8 @@ tv.exportTo('tracing.tracks', function() {
   ProcessTrack.prototype = {
     __proto__: ProcessTrackBase.prototype,
 
+    TRACK_CLASS_NAME_: 'ProcessTrack',
+
     decorate: function(viewport) {
       tracing.tracks.ProcessTrackBase.prototype.decorate.call(this, viewport);
     },

--- a/trace_viewer/tracing/tracks/process_track_base.html
+++ b/trace_viewer/tracing/tracks/process_track_base.html
@@ -38,6 +38,8 @@ tv.exportTo('tracing.tracks', function() {
 
     __proto__: tracing.tracks.ContainerTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'ProcessTrackBase',
+
     decorate: function(viewport) {
       tracing.tracks.ContainerTrack.prototype.decorate.call(this, viewport);
 

--- a/trace_viewer/tracing/tracks/rect_track.html
+++ b/trace_viewer/tracing/tracks/rect_track.html
@@ -30,6 +30,8 @@ tv.exportTo('tracing.tracks', function() {
 
     __proto__: tracing.tracks.HeadingTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'RectTrack',
+
     decorate: function(viewport) {
       tracing.tracks.HeadingTrack.prototype.decorate.call(this, viewport);
       this.classList.add('rect-track');

--- a/trace_viewer/tracing/tracks/ruler_track.html
+++ b/trace_viewer/tracing/tracks/ruler_track.html
@@ -32,6 +32,8 @@ tv.exportTo('tracing.tracks', function() {
   RulerTrack.prototype = {
     __proto__: tracing.tracks.HeadingTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'RulerTrack',
+
     decorate: function(viewport) {
       tracing.tracks.HeadingTrack.prototype.decorate.call(this, viewport);
       this.classList.add('ruler-track');

--- a/trace_viewer/tracing/tracks/sample_track.html
+++ b/trace_viewer/tracing/tracks/sample_track.html
@@ -23,6 +23,8 @@ tv.exportTo('tracing.tracks', function() {
 
     __proto__: tracing.tracks.RectTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'SampleTrack',
+
     decorate: function(viewport) {
       tracing.tracks.RectTrack.prototype.decorate.call(this, viewport);
     },

--- a/trace_viewer/tracing/tracks/slice_group_track.html
+++ b/trace_viewer/tracing/tracks/slice_group_track.html
@@ -25,6 +25,8 @@ tv.exportTo('tracing.tracks', function() {
 
     __proto__: tracing.tracks.MultiRowTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'SliceGroupTrack',
+
     decorate: function(viewport) {
       tracing.tracks.MultiRowTrack.prototype.decorate.call(this, viewport);
       this.classList.add('slice-group-track');

--- a/trace_viewer/tracing/tracks/slice_track.html
+++ b/trace_viewer/tracing/tracks/slice_track.html
@@ -23,6 +23,8 @@ tv.exportTo('tracing.tracks', function() {
 
     __proto__: tracing.tracks.RectTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'SliceTrack',
+
     decorate: function(viewport) {
       tracing.tracks.RectTrack.prototype.decorate.call(this, viewport);
     },

--- a/trace_viewer/tracing/tracks/spacing_track.html
+++ b/trace_viewer/tracing/tracks/spacing_track.html
@@ -22,6 +22,8 @@ tv.exportTo('tracing.tracks', function() {
   SpacingTrack.prototype = {
     __proto__: tracing.tracks.HeadingTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'SpacingTrack',
+
     decorate: function(viewport) {
       tracing.tracks.HeadingTrack.prototype.decorate.call(this, viewport);
       this.classList.add('spacing-track');

--- a/trace_viewer/tracing/tracks/stacked_bars_track.html
+++ b/trace_viewer/tracing/tracks/stacked_bars_track.html
@@ -25,6 +25,8 @@ tv.exportTo('tracing.tracks', function() {
 
     __proto__: tracing.tracks.HeadingTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'StackedBarsTrack',
+
     decorate: function(viewport) {
       tracing.tracks.HeadingTrack.prototype.decorate.call(this, viewport);
       this.classList.add('stacked-bars-track');

--- a/trace_viewer/tracing/tracks/thread_track.html
+++ b/trace_viewer/tracing/tracks/thread_track.html
@@ -29,6 +29,8 @@ tv.exportTo('tracing.tracks', function() {
   ThreadTrack.prototype = {
     __proto__: tracing.tracks.ContainerTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'ThreadTrack',
+
     decorate: function(viewport) {
       tracing.tracks.ContainerTrack.prototype.decorate.call(this, viewport);
       this.classList.add('thread-track');

--- a/trace_viewer/tracing/tracks/trace_model_track.html
+++ b/trace_viewer/tracing/tracks/trace_model_track.html
@@ -29,6 +29,8 @@ tv.exportTo('tracing.tracks', function() {
 
     __proto__: tracing.tracks.ContainerTrack.prototype,
 
+    TRACK_CLASS_NAME_: 'TraceModelTrack',
+
     decorate: function(viewport) {
       tracing.tracks.ContainerTrack.prototype.decorate.call(this, viewport);
       this.classList.add('model-track');

--- a/trace_viewer/tracing/tracks/track.html
+++ b/trace_viewer/tracing/tracks/track.html
@@ -27,6 +27,8 @@ tv.exportTo('tracing.tracks', function() {
   Track.prototype = {
     __proto__: tv.ui.ContainerThatDecoratesItsChildren.prototype,
 
+    TRACK_CLASS_NAME_: 'Track',
+
     decorate: function(viewport) {
       tv.ui.ContainerThatDecoratesItsChildren.prototype.decorate.call(this);
       if (viewport === undefined)

--- a/trace_viewer/tracing/tracks/track_visitor.html
+++ b/trace_viewer/tracing/tracks/track_visitor.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2014 The Chromium Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<link rel="import" href="/base.html">
+<link rel="import" href="/tracing/tracks/track.html">
+
+<script>
+'use strict';
+
+/**
+ * @fileoverview Provides the TrackVisitor class.
+ */
+tv.exportTo('tracing.tracks', function() {
+
+  /**
+   * Visits subtracks of a given track.
+   * @constructor
+   */
+  function TrackVisitor(opt_strict) {
+    this.strict_ = !!opt_strict;
+  };
+
+  var visitUnknownTrack = function(/*track, arguments*/) {};
+
+  TrackVisitor.prototype = {
+    __proto__: Object.prototype,
+
+    visit: function(track /*arguments*/) {
+      if (track.TRACK_CLASS_NAME_ === undefined) {
+        this.visitUnknownTrack.apply(this, arguments);
+      } else {
+        var methodName = 'visit' + track.TRACK_CLASS_NAME_;
+        if (this[methodName] === undefined) {
+          this.visitTrack.apply(this, arguments);
+        } else {
+          this[methodName].apply(this, arguments);
+        }
+      }
+    },
+
+    visitAll_: function(tracks, args) {
+      args = [0].concat(args);
+      for (var i = 0; i < tracks.length; i++) {
+        var track = tracks[i];
+        // This check is necessary because ProcessTrackBase has a header child.
+        if (!(track instanceof tracing.tracks.Track)) {
+          continue;
+        }
+        args[0] = track;
+        this.visit.apply(this, args);
+      }
+    },
+
+    visitAsyncSliceGroupTrack: function(/*track, arguments*/) {
+      this.visitMultiRowTrack.apply(this, arguments);
+    },
+
+    visitContainerTrack: function(track /*arguments*/) {
+      this.visitHeadingTrack.apply(this, arguments);
+      this.visitAll_(track.children, Array.prototype.slice(arguments, 1));
+    },
+
+    visitCounterTrack: function(/*track, arguments*/) {
+      this.visitHeadingTrack.apply(this, arguments);
+    },
+
+    visitCpuTrack: function(/*track, arguments*/) {
+      this.visitContainerTrack.apply(this, arguments);
+    },
+
+    visitDrawingContainer: function(/*track, arguments*/) {
+      this.visitTrack.apply(this, arguments);
+    },
+
+    visitHeadingTrack: function(/*track, arguments*/) {
+      this.visitTrack.apply(this, arguments);
+    },
+
+    visitKernelTrack: function(/*track, arguments*/) {
+      this.visitProcessTrackBase.apply(this, arguments);
+    },
+
+    visitMultiRowTrack: function(/*track, arguments*/) {
+      this.visitContainerTrack.apply(this, arguments);
+    },
+
+    visitObjectInstanceGroupTrack: function(/*track, arguments*/) {
+      this.visitMultiRowTrack.apply(this, arguments);
+    },
+
+    visitObjectInstanceTrack: function(/*track, arguments*/) {
+      this.visitHeadingTrack.apply(this, arguments);
+    },
+
+    visitProcessTrack: function(/*track, arguments*/) {
+      this.visitProcessTrackBase.apply(this, arguments);
+    },
+
+    visitProcessTrackBase: function(/*track, arguments*/) {
+      this.visitContainerTrack.apply(this, arguments);
+    },
+
+    visitRectTrack: function(/*track, arguments*/) {
+      this.visitHeadingTrack.apply(this, arguments);
+    },
+
+    visitRulerTrack: function(/*track, arguments*/) {
+      this.visitHeadingTrack.apply(this, arguments);
+    },
+
+    visitSampleTrack: function(/*track, arguments*/) {
+      this.visitRectTrack.apply(this, arguments);
+    },
+
+    visitSliceGroupTrack: function(/*track, arguments*/) {
+      this.visitMultiRowTrack.apply(this, arguments);
+    },
+
+    visitSliceTrack: function(/*track, arguments*/) {
+      this.visitRectTrack.apply(this, arguments);
+    },
+
+    visitSpacingTrack: function(/*track, arguments*/) {
+      this.visitHeadingTrack.apply(this, arguments);
+    },
+
+    visitStackedBarsTrack: function(/*track, arguments*/) {
+      this.visitHeadingTrack.apply(this, arguments);
+    },
+
+    visitThreadTrack: function(/*track, arguments*/) {
+      this.visitContainerTrack.apply(this, arguments);
+    },
+
+    visitTraceModelTrack: function(/*track, arguments*/) {
+      this.visitContainerTrack.apply(this, arguments);
+    },
+
+    visitTrack: function(/*track, arguments*/) {
+      if (this.strict_) {
+        throw new Error('undefined visitor method')
+      }
+    },
+
+    visitUnknownTrack: function(/*track, arguments*/) {
+      if (this.strict_) {
+        throw new Error('unknown track type');
+      }
+    }
+  };
+
+  return {
+    TrackVisitor: TrackVisitor
+  };
+});
+</script>
+

--- a/trace_viewer/tracing/tracks/track_visitor_test.html
+++ b/trace_viewer/tracing/tracks/track_visitor_test.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2014 The Chromium Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<link rel="import" href="/tracing/timeline_track_view.html">
+<link rel="import" href="/tracing/trace_model/thread.html">
+<link rel="import" href="/tracing/tracks/drawing_container.html">
+<link rel="import" href="/tracing/tracks/sample_track.html">
+<link rel="import" href="/tracing/tracks/trace_model_track.html">
+<link rel="import" href="/tracing/tracks/track_visitor.html">
+
+<script>
+'use strict';
+
+tv.unittest.testSuite(function() {
+  var ThreadSlice = tracing.trace_model.ThreadSlice;
+  var SampleTrack = tracing.tracks.SampleTrack;
+  var TraceModelTrack = tracing.tracks.TraceModelTrack
+  var TrackVisitor = tracing.tracks.TrackVisitor;
+
+  test('visitTrackDirectly', function() {
+    var track = new SampleTrack(new tracing.TimelineViewport());
+
+    var visited = false;
+    var visitor = new TrackVisitor(true);
+    visitor.visitSampleTrack = function() {
+      visited = true;
+    }
+    visitor.visit(track);
+    assertTrue(visited);
+  });
+
+  test('visitTrackSuper', function() {
+    var track = new SampleTrack(new tracing.TimelineViewport());
+
+    var visited = false;
+    var visitor = new TrackVisitor(true);
+    visitor.visitTrack = function() {
+      visited = true;
+    }
+    visitor.visit(track);
+    assertTrue(visited);
+  })
+
+  var PROCESS_COUNT = 3;
+  var THREADS_PER_PROCESS = 4;
+
+  test('visitTrackContainers', function() {
+    var model = new tracing.TraceModel();
+    for (var i = 0; i < PROCESS_COUNT; i++) {
+      var p = model.getOrCreateProcess(i);
+      for (var j = 0; j < THREADS_PER_PROCESS; j++) {
+        var t = p.getOrCreateThread(j);
+        t.sliceGroup.pushSlice(new ThreadSlice('', 'a', 0, 1, {}, 4));
+      }
+    }
+
+    var viewport = new tracing.TimelineViewport()
+    var track = new TraceModelTrack(viewport);
+    viewport.modelTrackContainer = new tracing.tracks.DrawingContainer(
+        viewport);
+    track.model = model;
+
+    var visited = 0;
+    var visitor = new TrackVisitor(true);
+    visitor.visitTrack = function() {
+      visited++;
+    }
+    visitor.visit(track);
+    // 1x TraceModelTrack
+    //   PROCESS_COUNTx ProcessTrack
+    //     THREADS_PER_PROCESSx ThreadTrack
+    //       1x SliceGroupTrack
+    //       1x RectTrack
+    //     THREADS_PER_PROCESSx SpacingTrack
+    assertEquals(1 + PROCESS_COUNT * (1 + THREADS_PER_PROCESS * 4), visited);
+  })
+});
+</script>
+


### PR DESCRIPTION
This patch adds an abstract <tt>tracing.tracks.TrackVisitor</tt> class which recursively traverses all subtracks of a given track. It will be used by the _VSync highlighter_ (see #662) and could be reused by existing parts of the tool.
