### PR TITLE
Support Tracing.bufferUsage percentFull param

### DIFF
--- a/trace_viewer/about_tracing/inspector_tracing_controller_client.html
+++ b/trace_viewer/about_tracing/inspector_tracing_controller_client.html
@@ -112,7 +112,7 @@ tv.exportTo('about_tracing', function() {
     },
 
     onBufferUsageUpdateFromInspector_: function(params) {
-      this.bufferUsage_ = params.value;
+      this.bufferUsage_ = params.value || params.percentFull;
     },
 
     beginGetBufferPercentFull: function() {


### PR DESCRIPTION
I'm going to extend Tracein.bufferUsage event with additional information. The value param is being renamed to more descriptive percentFull (see Blink change https://codereview.chromium.org/722693002/). This changes prepares trace-viewer for the protocol changes.
