### PR TITLE
Reduce button presses to get a specific presetted trace

### DIFF
--- a/trace_viewer/about_tracing/record_selection_dialog.html
+++ b/trace_viewer/about_tracing/record_selection_dialog.html
@@ -119,7 +119,6 @@ found in the LICENSE file.
   <div class="record-selection-dialog">
     <x-info-bar-group></x-info-bar-group>
     <div class="category-presets">
-      Settings preset:
     </div>
     <div class="category-description"></div>
     <div class="categories-column-view">
@@ -201,10 +200,9 @@ tv.exportTo('about_tracing', function() {
       this.recordButtonEl_.style.fontSize = '110%';
       this.buttons.appendChild(this.recordButtonEl_);
 
-
       this.categoriesView_ = this.querySelector('.categories-column-view');
       this.presetsEl_ = this.querySelector('.category-presets');
-      this.presetsEl_.appendChild(tv.ui.createSelector(
+      this.presetsEl_.appendChild(tv.ui.createOptionGroup(
           this, 'currentlyChosenPreset',
           'about_tracing.record_selection_dialog_preset',
           DEFAULT_PRESETS[0].categoryFilter,
@@ -243,6 +241,7 @@ tv.exportTo('about_tracing', function() {
           this.querySelector('.default-disabled-categories'));
       this.createDefaultDisabledWarningDialog_(
           this.querySelector('.warning-default-disabled-categories'));
+      this.editCategoriesOpened_ = false;
 
       // TODO(chrishenry): When used with tv.ui.Overlay (such as in
       // chrome://tracing, this does not yet look quite right due to
@@ -321,12 +320,38 @@ tv.exportTo('about_tracing', function() {
             ' preset must be an array.');
       this.currentlyChosenPreset_ = preset;
 
-      var classList = this.categoriesView_.classList;
-      if (!this.usingPreset_())
-        classList.remove('categories-column-view-hidden');
-      else if (!classList.contains('categories-column-view-hidden'))
-        classList.add('categories-column-view-hidden');
+      this.updateManualCategorySelectionStatus_();
       this.updatePresetDescription_();
+    },
+
+    updateManualCategorySelectionStatus_: function() {
+      var classList = this.categoriesView_.classList;
+      if (!this.usingPreset_()) {
+        classList.remove('categories-column-view-hidden');
+        this.updateEditCategoriesStatus_(true);
+      } else {
+        if (this.editCategoriesOpened_)
+          classList.remove('categories-column-view-hidden');
+        else
+          classList.add('categories-column-view-hidden');
+      }
+    },
+
+    onClickEditCategories: function() {
+      this.updateEditCategoriesStatus_(!this.editCategoriesOpened_);
+      this.updateManualCategorySelectionStatus_();
+    },
+
+    updateEditCategoriesStatus_: function(editCategoriesState) {
+      var presetOptionsGroup = this.querySelector('.labeled-option-group');
+      if (!presetOptionsGroup)
+        return;
+
+      this.editCategoriesOpened_ = editCategoriesState;
+      if (this.editCategoriesOpened_)
+          presetOptionsGroup.classList.add('categories-expanded');
+      else
+          presetOptionsGroup.classList.remove('categories-expanded');
     },
 
     updatePresetDescription_: function() {

--- a/trace_viewer/base/ui/dom_helpers.html
+++ b/trace_viewer/base/ui/dom_helpers.html
@@ -44,15 +44,16 @@ tv.exportTo('tv.ui', function() {
     return styleEl;
   }
 
+  function valuesEqual(a, b) {
+    if (a instanceof Array && b instanceof Array)
+      return a.length === b.length && JSON.stringify(a) === JSON.stringify(b);
+    return a === b;
+  }
+
   function createSelector(
       targetEl, targetElProperty,
       settingsKey, defaultValue,
       items, opt_namespace) {
-    function valuesEqual(a, b) {
-      if (a instanceof Array && b instanceof Array)
-        return a.length == b.length && JSON.stringify(a) == JSON.stringify(b);
-      return a == b;
-    }
     var defaultValueIndex;
     for (var i = 0; i < items.length; i++) {
       var item = items[i];
@@ -117,6 +118,79 @@ tv.exportTo('tv.ui', function() {
     return selectorEl;
   }
 
+  function createEditCategorySpan(optionGroupEl, targetEl) {
+    var spanEl = createSpan({className: 'edit-categories'});
+    spanEl.textContent = 'Edit categories';
+    spanEl.classList.add('labeled-option');
+
+    spanEl.addEventListener('click', function() {
+      targetEl.onClickEditCategories();
+    });
+    return spanEl;
+  }
+
+  function createOptionGroup(targetEl, targetElProperty,
+                             settingsKey, defaultValue,
+                             items) {
+    function onChange() {
+      var value = [];
+      if (this.value.length)
+        value = this.value.split(',');
+      tv.Settings.set(settingsKey, value);
+      targetEl[targetElProperty] = value;
+    }
+
+    var optionGroupEl = createSpan({className: 'labeled-option-group'});
+    var initialValue = tv.Settings.get(settingsKey, defaultValue);
+    var didSetInitialValue = false;
+    for (var i = 0; i < items.length; ++i) {
+      var item = items[i];
+      var id = 'category-preset-' + i;
+
+      var radioEl = document.createElement('input');
+      radioEl.type = 'radio';
+      radioEl.setAttribute('id', id);
+      radioEl.setAttribute('name', 'category-presets-group');
+      radioEl.setAttribute('value', item.value);
+      radioEl.addEventListener('change', onChange.bind(radioEl, targetEl,
+                                                       targetElProperty,
+                                                       settingsKey));
+      if (valuesEqual(initialValue, item.value)) {
+        radioEl.checked = true;
+        targetEl[targetElProperty] = initialValue;
+        didSetInitialValue = true;
+      }
+
+      var labelEl = document.createElement('label');
+      labelEl.textContent = item.label;
+      labelEl.setAttribute('for', id);
+
+      var spanEl = createSpan({className: 'labeled-option'});
+      spanEl.appendChild(radioEl);
+      spanEl.appendChild(labelEl);
+
+      spanEl.__defineSetter__('checked', function(opt_bool) {
+        var changed = radioEl.checked !== (!!opt_bool);
+        if (!changed)
+          return;
+
+        radioEl.checked = !!opt_bool;
+        onChange();
+      });
+      spanEl.__defineGetter__('checked', function() {
+        return radioEl.checked;
+      });
+
+      optionGroupEl.appendChild(spanEl);
+    }
+    optionGroupEl.appendChild(createEditCategorySpan(optionGroupEl, targetEl));
+
+    if (!didSetInitialValue)
+      targetEl[targetElProperty] = defaultValue;
+
+    return optionGroupEl;
+  }
+
   var nextCheckboxId = 1;
   function createCheckBox(targetEl, targetElProperty,
                           settingsKey, defaultValue,
@@ -175,6 +249,7 @@ tv.exportTo('tv.ui', function() {
     createDiv: createDiv,
     createScopedStyle: createScopedStyle,
     createSelector: createSelector,
+    createOptionGroup: createOptionGroup,
     createCheckBox: createCheckBox,
     isElementAttachedToDocument: isElementAttachedToDocument
   };

--- a/trace_viewer/cc/layer_view.css
+++ b/trace_viewer/cc/layer_view.css
@@ -30,3 +30,32 @@ layer-view > layer-view-analysis * {
 .labeled-checkbox {
   white-space: nowrap;
 }
+
+.labeled-option-group {
+  -webkit-flex: 0 0 auto;
+  -webkit-flex-direction: column;
+  -webkit-align-items: left;
+  display: -webkit-flex;
+}
+
+.labeled-option {
+  border-top: 5px solid white;
+  border-bottom: 5px solid white;
+}
+
+.edit-categories {
+  padding-left: 6px;
+}
+
+.edit-categories:after {
+  padding-left: 15px;
+  font-size: 125%;
+}
+
+.labeled-option-group:not(.categories-expanded) .edit-categories:after {
+  content: '\25B8'; /* Right triangle */
+}
+
+.labeled-option-group.categories-expanded .edit-categories:after {
+  content: '\25BE'; /* Down triangle */
+}


### PR DESCRIPTION
Users of tracing many times uses predefined preset modes e.g.
Web Developer, Frame Viewer, Input Latency etc.
This involves pressing 'Record', then choosing the preset option
from dropdown and then pressing Record button.

Instead we can list presets as options, where clicking on the preset
starts recording with the pre-defined trace categories. Only if we
choose "manual settings" mode, we need to press Record button.

The UX changes of this CL are as per the wireframes suggested by pdr
in the document:
https://docs.google.com/a/chromium.org/drawings/d/1fTlQyI2vdJoVzMqmdX9qRQsZIdJ1zzz_FCCEKfJ5S8M/edit

BUG=603

R=nduca,dsinclair,pdr
