### PR TITLE
Fix #671 (Importer skipping initial systrace entries)

### DIFF
--- a/trace_viewer/tracing/importer/linux_perf_importer.html
+++ b/trace_viewer/tracing/importer/linux_perf_importer.html
@@ -688,18 +688,11 @@ tv.exportTo('tracing.importer', function() {
     parseLines: function() {
       var extractResult = LinuxPerfImporter._extractEventsFromSystraceHTML(
           this.events_, true);
-      var lineNumberBase = 0;
-      var lines;
-      if (extractResult.ok) {
-        lineNumberBase = extractResult.events_begin_at_line;
-        lines = extractResult.lines;
-      } else
-        lines = this.events_.split('\n');
+      var lines = extractResult.ok ?
+          extractResult.lines : this.events_.split('\n');
 
       var lineParser = null;
-      for (var lineNumber = lineNumberBase;
-           lineNumber < lines.length;
-          ++lineNumber) {
+      for (var lineNumber = 0; lineNumber < lines.length; ++lineNumber) {
         var line = lines[lineNumber];
         if (line.length == 0 || /^#/.test(line))
           continue;

--- a/trace_viewer/tracing/importer/linux_perf_importer_test.html
+++ b/trace_viewer/tracing/importer/linux_perf_importer_test.html
@@ -258,6 +258,54 @@ tv.unittest.testSuite(function() { // @suppress longLineCheck
     assertFalse(m.hasImportWarnings);
   });
 
+  test('importHtml', function() {
+    var lines = [
+      '<!DOCTYPE HTML>',
+      '<html>',
+      '<head i18n-values="dir:textdirection;">',
+      '<title>Android System Trace</title>',
+      '<style type="text/css">tabbox{display:-webkit-box;}</style>',
+      '<script language="javascript">\'use strict\';function onLoad(){};',
+      'document.addEventListener("click",function(g){});',
+      '<\/script>',
+      '<style>',
+      '  .view {',
+      '    overflow: hidden;',
+      '  }',
+      '</style>',
+      '</head>',
+      '<body>',
+      '  <div class="view">',
+      '  </div>',
+      '  <script>',
+      '  \'use strict\';',
+      '  var linuxPerfData = "\\',
+      '# tracer: nop\\n\\',
+      '#\\n\\',
+      '#            TASK-PID    CPU#    TIMESTAMP  FUNCTION\\n\\',
+      '#               | |       |          |         |\\n\\',
+      '     hwc_eventmon-336   [000] 50260.929925: 0: C|124|VSYNC|1\\n\\',
+      '         Binder_1-340   [000] 50260.935656: 0: C|124|StatusBar|1\\n\\',
+      '     hwc_eventmon-336   [000] 50260.946573: 0: C|124|VSYNC|0\\n\\',
+      '      InputReader-419   [000] 50262.538578: 0: C|360|iq|1\\n";',
+      '  <\/script>',
+      '</body>',
+      '</html>'
+     ];
+     var m = new tracing.TraceModel(lines.join('\n'), false);
+     assertFalse(m.hasImportWarnings);
+
+     assertNotUndefined(m.processes[124]);
+     assertNotUndefined(m.processes[360]);
+
+     assertNotUndefined(m.processes[124].counters['android.StatusBar']);
+     assertEquals(m.processes[124].counters['android.StatusBar'].numSamples, 1);
+     assertNotUndefined(m.processes[124].counters['android.VSYNC']);
+     assertEquals(m.processes[124].counters['android.VSYNC'].numSamples, 2);
+     assertNotUndefined(m.processes[360].counters['android.iq']);
+     assertEquals(m.processes[360].counters['android.iq'].numSamples, 1);
+   });
+
   test('clockSync', function() {
     var lines = [
       '          <idle>-0     [001]  4467.843475: sched_switch: ' +


### PR DESCRIPTION
This patch fixes #671 (Importer skipping initial systrace entries) which was caused by <tt>LinuxPerfImporter</tt>.
