### PR TITLE
Add a perf test for CounterTrack class

### DIFF
--- a/test_data/counter_tracks.html
+++ b/test_data/counter_tracks.html
@@ -1,0 +1,1804 @@
+<!DOCTYPE HTML>
+<html>
+<head i18n-values="dir:textdirection;">
+<title>Android System Trace</title>
+<style type="text/css">tabbox{-webkit-box-orient:vertical;display:-webkit-box;}tabs{-webkit-padding-start:8px;background:-webkit-linear-gradient(white,#f3f3f3);border-bottom:1px solid #a0a0a0;display:-webkit-box;margin:0;}tabs>*{-webkit-margin-start:5px;-webkit-transition:border-color 150ms,background-color 150ms;background:rgba(160,160,160,.3);border:1px solid rgba(160,160,160,.3);border-bottom:0;border-top-left-radius:3px;border-top-right-radius:3px;cursor:default;display:block;min-width:4em;padding:2px 10px;text-align:center;}tabs>:not([selected]){background:rgba(238,238,238,.3);}tabs>:not([selected]):hover{background:rgba(247,247,247,.3);}tabs>[selected]{-webkit-transition:none;background:white;border-color:#a0a0a0;margin-bottom:-1px;position:relative;z-index:0;}tabs:focus{outline:none;}html.focus-outline-visible tabs:focus>[selected]{outline:5px auto -webkit-focus-ring-color;outline-offset:-2px;}tabpanels{-webkit-box-flex:1;background:white;box-shadow:2px 2px 5px rgba(0,0,0,.2);display:-webkit-box;padding:5px 15px 0 15px;}tabpanels>*{-webkit-box-flex:1;display:none;}tabpanels>[selected]{display:block;}button:not(.custom-appearance):not(.link-button),input[type='button']:not(.custom-appearance):not(.link-button),input[type='submit']:not(.custom-appearance):not(.link-button),select,input[type='checkbox'],input[type='radio']{-webkit-appearance:none;-webkit-user-select:none;background-image:-webkit-linear-gradient(#ededed,#ededed 38%,#dedede);border:1px solid rgba(0,0,0,0.25);border-radius:2px;box-shadow:0 1px 0 rgba(0,0,0,0.08),inset 0 1px 2px rgba(255,255,255,0.75);color:#444;font:inherit;margin:0 1px 0 0;text-shadow:0 1px 0 #f0f0f0;}button:not(.custom-appearance):not(.link-button),input[type='button']:not(.custom-appearance):not(.link-button),input[type='submit']:not(.custom-appearance):not(.link-button),select{min-height:2em;min-width:4em;<if expr="pp_ifdef('chromeos')">padding-top:3px;</if><if expr="is_win">padding-bottom:1px;</if>;}button:not(.custom-appearance):not(.link-button),input[type='button']:not(.custom-appearance):not(.link-button),input[type='submit']:not(.custom-appearance):not(.link-button){-webkit-padding-end:10px;-webkit-padding-start:10px;}select{-webkit-appearance:none;-webkit-padding-end:20px;-webkit-padding-start:6px;background-image:url('../images/select.png'),-webkit-linear-gradient(#ededed,#ededed 38%,#dedede);background-position:right center;background-repeat:no-repeat;}html[dir='rtl'] select{background-position:center left;}input[type='checkbox']{bottom:2px;height:13px;position:relative;vertical-align:middle;width:13px;}input[type='radio']{border-radius:100%;bottom:3px;height:15px;position:relative;vertical-align:middle;width:15px;}input[type='password'],input[type='search'],input[type='text'],input[type='url'],input:not([type]){border:1px solid #bfbfbf;border-radius:2px;box-sizing:border-box;color:#444;font:inherit;margin:0;min-height:2em;padding:3px;<if expr="is_win or is_macosx">padding-bottom:4px;</if><if expr="pp_ifdef('chromeos')">padding-bottom:2px;</if>;}input[type='search']{-webkit-appearance:textfield;min-width:160px;}input[type='checkbox']:checked::before{-webkit-user-select:none;background-image:url('../images/check.png');background-size:100% 100%;content:'';display:block;height:100%;width:100%;}html[dir='rtl'] input[type='checkbox']:checked::before{-webkit-transform:scaleX(-1);}input[type='radio']:checked::before{background-color:#666;border-radius:100%;bottom:25%;content:'';display:block;left:25%;position:absolute;right:25%;top:25%;}button:not(.custom-appearance):not(.link-button):enabled:hover,input[type='button']:not(.custom-appearance):not(.link-button):enabled:hover,input[type='submit']:not(.custom-appearance):not(.link-button):enabled:hover,select:enabled:hover,input[type='checkbox']:enabled:hover,input[type='radio']:enabled:hover{background-image:-webkit-linear-gradient(#f0f0f0,#f0f0f0 38%,#e0e0e0);border-color:rgba(0,0,0,0.3);box-shadow:0 1px 0 rgba(0,0,0,0.12),inset 0 1px 2px rgba(255,255,255,0.95);color:black;}select:enabled:hover{background-image:url('../images/select.png'),-webkit-linear-gradient(#f0f0f0,#f0f0f0 38%,#e0e0e0);}button:not(.custom-appearance):not(.link-button):enabled:active,input[type='button']:not(.custom-appearance):not(.link-button):enabled:active,input[type='submit']:not(.custom-appearance):not(.link-button):enabled:active,select:enabled:active,input[type='checkbox']:enabled:active,input[type='radio']:enabled:active{background-image:-webkit-linear-gradient(#e7e7e7,#e7e7e7 38%,#d7d7d7);box-shadow:none;text-shadow:none;}select:enabled:active{background-image:url('../images/select.png'),-webkit-linear-gradient(#e7e7e7,#e7e7e7 38%,#d7d7d7);}button:not(.custom-appearance):not(.link-button):disabled,input[type='button']:not(.custom-appearance):not(.link-button):disabled,input[type='submit']:not(.custom-appearance):not(.link-button):disabled,select:disabled{background-image:-webkit-linear-gradient(#f1f1f1,#f1f1f1 38%,#e6e6e6);border-color:rgba(80,80,80,0.2);box-shadow:0 1px 0 rgba(80,80,80,0.08),inset 0 1px 2px rgba(255,255,255,0.75);color:#aaa;}select:disabled{background-image:url('../images/disabled_select.png'),-webkit-linear-gradient(#f1f1f1,#f1f1f1 38%,#e6e6e6);}input[type='checkbox']:disabled,input[type='radio']:disabled{opacity:.75;}input[type='password']:disabled,input[type='search']:disabled,input[type='text']:disabled,input[type='url']:disabled,input:not([type]):disabled{color:#999;}button:not(.custom-appearance):not(.link-button):enabled:focus,input[type='button']:not(.custom-appearance):enabled:focus,input[type='checkbox']:enabled:focus,input[type='password']:enabled:focus,input[type='radio']:enabled:focus,input[type='search']:enabled:focus,input[type='submit']:not(.custom-appearance):enabled:focus,input[type='text']:enabled:focus,input[type='url']:enabled:focus,input:not([type]):enabled:focus,select:enabled:focus{-webkit-transition:border-color 200ms;border-color:#4d90fe;outline:none;}.link-button{-webkit-box-shadow:none;background:transparent none;border:none;color:#15c;cursor:pointer;font:inherit;margin:0;padding:0 4px;}.link-button:hover{text-decoration:underline;}.link-button:active{color:#052577;text-decoration:underline;}.link-button[disabled]{color:#999;cursor:default;text-decoration:none;}.checkbox,.radio{margin:.65em 0;}.checkbox label,.radio label{display:-webkit-inline-box;}.checkbox label input ~ span,.radio label input ~ span{-webkit-margin-start:.6em;display:block;}.checkbox label:hover,.radio label:hover{color:black;}label>input[type=checkbox]:disabled ~ span,label>input[type=radio]:disabled ~ span{color:#999;}.overlay-root{-webkit-box-align:stretch;-webkit-box-orient:horizontal;-webkit-box-pack:center;-webkit-user-select:none;background:rgba(0,0,0,0.8);display:-webkit-box;height:100%;left:0;position:fixed;top:0;width:100%;z-index:1000;}.overlay-root:not([visible]),.overlay:not([visible]){display:none;}.overlay-root>.content-host{-webkit-box-align:stretch;-webkit-box-orient:vertical;-webkit-box-pack:center;-webkit-user-select:auto;display:-webkit-box;}.overlay-root>.content-host>*{background:#fff;}.profiling-view{-webkit-box-flex:1;-webkit-box-orient:vertical;display:-webkit-box;padding:0;}.profiling-view>.container{-webkit-box-flex:1;display:-webkit-box;}.profiling-overlay{-webkit-box-orient:vertical;display:-webkit-box;text-align:center;}.profiling-overlay .raw-text{-webkit-box-flex:1;overflow:auto;wrap:none;}.profiling-overlay .error{border:1px solid red;text-align:center;}.timeline-analysis{-webkit-user-select:text;font-family:monospace;white-space:pre;}.timeline-view{-webkit-box-flex:1;-webkit-box-orient:vertical;display:-webkit-box;padding:0;}.timeline-view>.control{display:-webkit-box;}.timeline-view>.control>.controls{display:-webkit-box;}.timeline-view>.control>span{padding-left:5px;padding-right:10px;}.timeline-view>.control>button{font-size:75%;height:20px;min-height:10px;}.timeline-view>.control>.spacer{-webkit-box-flex:1;}.timeline-view>.timeline-viewport-track{display:-webkit-box;margin-top:6px;border-bottom:1px solid #AAA;}.timeline-view>.timeline-container{-webkit-box-flex:1;display:-webkit-box;overflow:auto;}.timeline-view>.timeline-container>*{-webkit-box-flex:1;}.timeline-view>.analysis-container{border-top:1px solid black;max-height:250px;min-height:250px;overflow:auto;}.timeline-view .selection{margin:2px;}.timeline-view .selection ul{margin:0;}.timeline-find-control{-webkit-user-select:none;display:-webkit-box;position:relative;}.timeline-find-control .hit-count-label{left:0;opacity:.25;pointer-events:none;position:absolute;text-align:right;top:2px;width:170px;z-index:1;}.timeline-find-control input{-webkit-user-select:auto;border:1px solid rgba(0,0,0,0.4);box-sizing:border-box;height:19px;margin-bottom:1px;margin-left:0;margin-right:0;margin-top:1px;padding:0;width:170px;}.timeline-button.find-previous{border-left:none;margin-left:0;margin-right:0;}.timeline-button.find-next{border-bottom-right-radius:5px;border-left:none;margin-left:0;}.timeline-button{background-color:rgba(255,255,255,0.5);border:1px solid rgba(0,0,0,0.2);color:rgba(0,0,0,0.2);font-size:14px;height:17px;margin:1px;text-align:center;width:23px;}.timeline-button:hover{background-color:rgba(255,255,255,1.0);border:1px solid rgba(0,0,0,0.8);box-shadow:0 0 .05em rgba(0,0,0,0.4);color:rgba(0,0,0,1);}.timeline *{-webkit-user-select:none;cursor:default;}.timeline-drag-box{background-color:rgba(0,0,255,0.25);border:1px solid #000060;font-size:75%;position:fixed;}.timeline-thread-track{-webkit-box-orient:vertical;display:-webkit-box;padding:1px 0;position:relative;}.timeline-track-button{background-color:rgba(255,255,255,0.5);border:1px solid rgba(0,0,0,0.1);color:rgba(0,0,0,0.2);font-size:10px;height:12px;text-align:center;width:12px;}.timeline-track-button:hover{background-color:rgba(255,255,255,1.0);border:1px solid rgba(0,0,0,0.5);border-radius:25%;box-shadow:0 0 .05em rgba(0,0,0,0.4);color:rgba(0,0,0,1);}.timeline-track-close-button{left:0;position:absolute;top:0;}.timeline-track-collapse-button{left:15px;position:absolute;top:0;}.timeline-thread-track:not(:first-child){border-top:1px solid #D0D0D0;}.timeline-canvas-based-track{-webkit-box-align:stretch;-webkit-box-orient:horizontal;background-color:white;display:-webkit-box;margin:0;padding:0 5px 0 0;}.timeline-canvas-based-track-title{overflow:hidden;padding-right:5px;text-align:right;text-overflow:ellipsis;white-space:nowrap;}.timeline-canvas-based-track-canvas-container{-webkit-box-flex:1;width:100%;}.timeline-canvas-based-track-canvas{-webkit-box-flex:1;display:block;height:100%;width:100%;}.timeline-viewport-track{height:12px;}.timeline-slice-track{height:18px;}.timeline-counter-track{height:30px;position:relative;}.tracing-overlay{-webkit-box-align:center;-webkit-box-orient:vertical;-webkit-box-pack:center;display:-webkit-box;height:80px;text-align:center;width:200px;}.tracing-start-button{-webkit-margin-start:5px;background:#f00;background-clip:border-box;border:1px solid black;border-bottom:0;border-top-left-radius:8px;border-top-right-radius:8px;display:inline-block;margin-top:4px;padding:5px 10px 3px 10px;position:fixed;right:3px;text-align:center;text-decoration:none;top:-1px;}</style>
+<script language="javascript">'use strict';function onLoad(){reload()}function reload(){if(linuxPerfData){var g=new tracing.TimelineModel;g.importEvents("[]",!0,[linuxPerfData]);var e=document.querySelector(".view");cr.ui.decorate(e,tracing.TimelineView);e.model=g;e.tabIndex=1;e.timeline.focusElement=e}}document.addEventListener("DOMContentLoaded",onLoad);var global=this;
+this.cr=function(){function g(a,b,c,f){var e=new cr.Event(b+"Change");e.propertyName=b;e.newValue=c;e.oldValue=f;a.dispatchEvent(e)}function e(a){return a.replace(/([A-Z])/g,"-$1").toLowerCase()}function c(b,c){switch(c){case a.JS:var f=b+"_";return function(){return this[f]};case a.ATTR:var h=e(b);return function(){return this.getAttribute(h)};case a.BOOL_ATTR:return h=e(b),function(){return this.hasAttribute(h)}}}function f(b,c,f){switch(c){case a.JS:var h=b+"_";return function(a){var c=this[h];
+a!==c&&(this[h]=a,f&&f.call(this,a,c),g(this,b,a,c))};case a.ATTR:var k=e(b);return function(a){var c=this[k];a!==c&&(void 0==a?this.removeAttribute(k):this.setAttribute(k,a),f&&f.call(this,a,c),g(this,b,a,c))};case a.BOOL_ATTR:return k=e(b),function(a){var c=this[k];a!==c&&(a?this.setAttribute(k,b):this.removeAttribute(k),f&&f.call(this,a,c),g(this,b,a,c))}}}function h(a,b,c){var f=cr.doc.createEvent("Event");f.initEvent(a,!!b,!!c);f.__proto__=global.Event.prototype;return f}var a={JS:"js",ATTR:"attr",
+BOOL_ATTR:"boolAttr"},b=1;return{addSingletonGetter:function(a){a.getInstance=function(){return a.instance_||(a.instance_=new a)}},createUid:function(){return b++},define:function(a,b){var c;c=a.split(".");for(var f=global,e;c.length&&(e=c.shift());)f=e in f?f[e]:f[e]={};c=f;var f=b(),h;for(h in f)(e=Object.getOwnPropertyDescriptor(f,h))&&Object.defineProperty(c,h,e)},defineProperty:function(b,e,h,g){"function"==typeof b&&(b=b.prototype);h=h||a.JS;b.__lookupGetter__(e)||b.__defineGetter__(e,c(e,h));
+b.__lookupSetter__(e)||b.__defineSetter__(e,f(e,h,g))},dispatchPropertyChange:g,dispatchSimpleEvent:function(a,b,c,f){b=new cr.Event(b,c,f);return a.dispatchEvent(b)},Event:h,getUid:function(a){return a.hasOwnProperty("uid")?a.uid:a.uid=b++},initialize:function(){if(global.document)h.prototype={__proto__:global.Event.prototype},cr.isMac=/Mac/.test(navigator.platform),cr.isWindows=/Win/.test(navigator.platform),cr.isChromeOS=/CrOS/.test(navigator.userAgent),cr.isLinux=/Linux/.test(navigator.userAgent),
+cr.isGTK=/GTK/.test(chrome.toolkit),cr.isViews=/views/.test(chrome.toolkit),cr.isTouchOptimized=!!chrome.touchOptimized,cr.isTouchOptimized&&doc.documentElement.setAttribute("touch-optimized","");else{var a=cr;Object.defineProperty(global,"cr",{get:function(){Object.defineProperty(global,"cr",{value:a});a.initialize();return a},configurable:!0})}},PropertyKind:a,get doc(){return document}}}();cr.initialize();cr.define("cr",function(){function g(){}g.prototype={addEventListener:function(e,c){this.listeners_||(this.listeners_=Object.create(null));if(e in this.listeners_){var f=this.listeners_[e];0>f.indexOf(c)&&f.push(c)}else this.listeners_[e]=[c]},removeEventListener:function(e,c){if(this.listeners_&&e in this.listeners_){var f=this.listeners_[e],h=f.indexOf(c);0<=h&&(1==f.length?delete this.listeners_[e]:f.splice(h,1))}},dispatchEvent:function(e){if(!this.listeners_)return!0;var c=this;e.__defineGetter__("target",
+function(){return c});e.preventDefault=function(){this.returnValue=!1};var f=e.type,h=0;if(f in this.listeners_)for(var f=this.listeners_[f].concat(),a=0,b;b=f[a];a++)h=b.handleEvent?h|!1===b.handleEvent.call(b,e):h|!1===b.call(this,e);return!h&&e.returnValue}};return{EventTarget:g}});cr.define("cr.ui",function(){function g(e,c){return(c&&c.ownerDocument?c.ownerDocument:cr.doc).createElement(e)}return{decorate:function(e,c){var f;f="string"==typeof e?cr.doc.querySelectorAll(e):[e];for(var h=0,a;a=f[h];h++)a instanceof c||c.decorate(a)},define:function(e){function c(a){var b=f(h,a);c.decorate(b);for(var d in a)b[d]=a[d];return b}var f,h;"function"==typeof e?(f=e,h=""):(f=g,h=e);c.decorate=function(a){a.__proto__=c.prototype;a.decorate()};return c},limitInputWidth:function(e,c,f){function h(){if(e.scrollWidth>
+g)e.style.width=g+"px";else{e.style.width=0;var a=e.scrollWidth;e.style.width=a<f?f+"px":a+"px"}}e.style.width="10px";var a=e.ownerDocument.defaultView,b=a.getComputedStyle(e),a=a.getComputedStyle(c),d="rtl"==b.direction,m=e.getBoundingClientRect(),i=c.getBoundingClientRect(),m=d?i.right-m.right:m.left-i.left,b=parseInt(b.borderLeftWidth,10)+parseInt(b.paddingLeft,10)+parseInt(b.paddingRight,10)+parseInt(b.borderRightWidth,10),a=d?parseInt(a.paddingLeft,10):parseInt(a.paddingRight,10),g=c.clientWidth-
+m-b-a;e.addEventListener("input",h);h()}}});cr.define("cr.ui",function(){function g(c){this.classList_=c.documentElement.classList;var f=this;c.addEventListener("keydown",function(c){9==c.keyCode&&(f.visible=!0)},!0);c.addEventListener("mousedown",function(){f.visible=!1},!0)}g.prototype={set visible(c){c?this.classList_.add("focus-outline-visible"):this.classList_.remove("focus-outline-visible")},get visible(){this.classList_.contains("focus-outline-visible")}};var e=[];g.forDocument=function(c){for(var f=0;f<e.length;f++)if(c==e[f][0])return e[f][1];
+f=new g(c);e.push([c,f]);return f};return{FocusOutlineManager:g}});cr.define("cr.ui",function(){function g(){for(var b={TABBOX:e,TABS:c,TAB:f,TABPANELS:h,TABPANEL:a},d,m=0;d=this.children[m];m++){var i=b[d.tagName];i&&cr.ui.decorate(d,i)}}var e=cr.ui.define("tabbox");e.prototype={__proto__:HTMLElement.prototype,decorate:function(){g.call(this);this.addEventListener("selectedChange",this.handleSelectedChange_,!0);this.selectedIndex=0},handleSelectedChange_:function(a){var d=a.target;a.newValue&&(d.parentElement&&d.parentElement.parentElement)==this&&(this.selectedIndex=
+Array.prototype.indexOf.call(d.parentElement.children,d))},selectedIndex_:-1};cr.defineProperty(e,"selectedIndex",cr.PropertyKind.JS_PROP,function(a){for(var d,c,f=0;d=this.children[f];f++)for(var e=0;c=d.children[e];e++)c.selected=e==a});var c=cr.ui.define("tabs");c.prototype={__proto__:HTMLElement.prototype,decorate:function(){g.call(this);this.tabIndex=0;this.addEventListener("keydown",this.handleKeyDown_.bind(this));this.focusOutlineManager_=cr.ui.FocusOutlineManager.forDocument(this.ownerDocument)},
+handleKeyDown_:function(a){var d=0;switch(a.keyIdentifier){case "Left":case "Up":d=-1;break;case "Right":case "Down":d=1}d&&("rtl"==this.ownerDocument.defaultView.getComputedStyle(this).direction&&(d*=-1),a=this.children.length,this.parentElement.selectedIndex=(this.parentElement.selectedIndex+d+a)%a,this.focusOutlineManager_.visible=!0)}};var f=cr.ui.define("tab");f.prototype={__proto__:HTMLElement.prototype,decorate:function(){var a=this;this.addEventListener(cr.isMac?"click":"mousedown",function(){a.selected=
+!0})}};cr.defineProperty(f,"selected",cr.PropertyKind.BOOL_ATTR);var h=cr.ui.define("tabpanels");h.prototype={__proto__:HTMLElement.prototype,decorate:g};var a=cr.ui.define("tabpanel");a.prototype={__proto__:HTMLElement.prototype,decorate:function(){}};cr.defineProperty(a,"selected",cr.PropertyKind.BOOL_ATTR);return{TabBox:e,Tabs:c,Tab:f,TabPanels:h,TabPanel:a}});global=this;function $(g){return document.getElementById(g)}function chromeSend(g,e,c,f){var h=global[c];global[c]=function(){global[c]=h;var a=Array.prototype.slice.call(arguments);return f.apply(global,a)};chrome.send(g,e)}function url(g){g=g.replace(/(\(|\)|\,|\s|\'|\"|\\)/g,"\\$1");/\\\\$/.test(g)&&(g+=" ");return'url("'+g+'")'}function parseQueryParams(g){for(var e={},g=unescape(g.search.substring(1)).split("&"),c=0;c<g.length;c++){var f=g[c].split("=");e[f[0]]=f[1]}return e}
+function findAncestorByClass(g,e){return findAncestor(g,function(c){return c.classList?c.classList.contains(e):null})}function findAncestor(g,e){for(var c=!1;null!=g&&!(c=e(g));)g=g.parentNode;return c?g:null}function swapDomNodes(g,e){var c=g.nextSibling;if(c==e)swapDomNodes(e,g);else{var f=g.parentNode;e.parentNode.replaceChild(g,e);f.insertBefore(e,c)}}
+function disableTextSelectAndDrag(){document.onselectstart=function(g){g.preventDefault()};document.ondragstart=function(g){g.preventDefault()}}function isRTL(){return"rtl"==document.documentElement.dir}function assert(g,e){if(!g){var c="Assertion failed";e&&(c=c+": "+e);throw Error(c);}}function getRequiredElement(g){var e=$(g);assert(e,"Missing required element: "+g);return e}
+document.addEventListener("click",function(g){if(g.returnValue){var e=g.target;if(e.nodeType==Node.ELEMENT_NODE&&e.webkitMatchesSelector("A, A *")){for(;"A"!=e.tagName;)e=e.parentElement;if(("file:"==e.protocol||"about:"==e.protocol)&&(0==g.button||1==g.button))chrome.send("navigateToUrl",[e.href,e.target,g.button,g.altKey,g.ctrlKey,g.metaKey,g.shiftKey]),g.preventDefault()}}});function appendParam(g,e,c){e=encodeURIComponent(e)+"="+encodeURIComponent(c);return-1==g.indexOf("?")?g+"?"+e:g+"&"+e};cr.define("tracing",function(){var g=cr.ui.define("div");g.prototype={__proto__:HTMLDivElement.prototype,decorate:function(){this.classList.add("overlay-root");this.visible=!1;this.contentHost=this.ownerDocument.createElement("div");this.contentHost.classList.add("content-host");this.tabCatcher=this.ownerDocument.createElement("span");this.tabCatcher.tabIndex=0;this.appendChild(this.contentHost);this.onKeydownBoundToThis_=this.onKeydown_.bind(this);this.onFocusInBoundToThis_=this.onFocusIn_.bind(this);
+this.addEventListener("mousedown",this.onMousedown_.bind(this))},showOverlay:function(c){c.oldParent_=c.parentNode;this.contentHost.appendChild(c);this.contentHost.appendChild(this.tabCatcher);this.ownerDocument.body.classList.add("disabled-by-overlay");this.visible=!0;c.tabIndex=0;var f=c.querySelector("button, input, list, select, a");f||(f=c);f.focus();this.ownerDocument.addEventListener("focusin",this.onFocusInBoundToThis_,!0);c.addEventListener("keydown",this.onKeydownBoundToThis_)},onMousedown_:function(c){c.target==
+this&&c.preventDefault()},onFocusIn_:function(c){c.target==this.tabCatcher&&window.setTimeout(this.focusOverlay_.bind(this),0)},focusOverlay_:function(){this.contentHost.firstChild.focus()},onKeydown_:function(c){9==c.keyCode&&(c.shiftKey&&c.target==this.contentHost.firstChild)&&c.preventDefault()},hideOverlay:function(c){this.visible=!1;this.ownerDocument.body.classList.remove("disabled-by-overlay");this.lastFocusOut_=void 0;c.parentNode.removeChild(this.tabCatcher);c.oldParent_?(c.oldParent_.appendChild(c),
+delete c.oldParent_):this.contentHost.removeChild(c);c.removeEventListener("keydown",this.onKeydownBoundToThis_);this.ownerDocument.removeEventListener("focusin",this.onFocusInBoundToThis_)}};cr.defineProperty(g,"visible",cr.PropertyKind.BOOL_ATTR);var e=cr.ui.define("div");e.prototype={__proto__:HTMLDivElement.prototype,decorate:function(){if(!this.ownerDocument.querySelector(".overlay-root")){var c=this.ownerDocument.createElement("div");cr.ui.decorate(c,g);this.ownerDocument.body.appendChild(c)}this.classList.add("overlay");
+this.visible=!1},onVisibleChanged_:function(){var c=this.ownerDocument.querySelector(".overlay-root");this.visible?c.showOverlay(this):c.hideOverlay(this)}};cr.defineProperty(e,"visible",cr.PropertyKind.BOOL_ATTR,e.prototype.onVisibleChanged_);return{Overlay:e}});cr.define("tracing",function(){function g(){this.overlay_=document.createElement("div");this.overlay_.className="tracing-overlay";cr.ui.decorate(this.overlay_,tracing.Overlay);this.statusDiv_=document.createElement("div");this.overlay_.appendChild(this.statusDiv_);this.bufferPercentDiv_=document.createElement("div");this.overlay_.appendChild(this.bufferPercentDiv_);this.stopButton_=document.createElement("button");this.stopButton_.onclick=this.endTracing.bind(this);this.stopButton_.textContent="Stop tracing";
+this.overlay_.appendChild(this.stopButton_);this.traceEvents_=[];this.systemTraceEvents_=[];this.onKeydownBoundToThis_=this.onKeydown_.bind(this);this.onKeypressBoundToThis_=this.onKeypress_.bind(this);chrome.send("tracingControllerInitialized")}g.prototype={__proto__:cr.EventTarget.prototype,gpuInfo_:void 0,clientInfo_:void 0,tracingEnabled_:!1,tracingEnding_:!1,systemTraceDataFilename_:void 0,onRequestBufferPercentFullComplete:function(e){this.overlay_.visible&&(window.setTimeout(this.beginRequestBufferPercentFull_.bind(this),
+250),this.bufferPercentDiv_.textContent="Buffer usage: "+Math.round(100*e)+"%")},beginRequestBufferPercentFull_:function(){chrome.send("beginRequestBufferPercentFull")},beginTracing:function(e){if(this.tracingEnabled_)throw Error("Tracing already begun.");this.stopButton_.hidden=!1;this.statusDiv_.textContent="Tracing active.";this.tracingEnabled_=this.overlay_.visible=!0;console.log("Beginning to trace...");this.statusDiv_.textContent="Tracing active.";this.traceEvents_=[];this.systemTraceEvents_=
+[];chrome.send("beginTracing",[e||!1]);this.beginRequestBufferPercentFull_();e=new cr.Event("traceBegun");e.events=this.traceEvents_;this.dispatchEvent(e);e=new cr.Event("traceEventsChanged");e.numEvents=this.traceEvents_.length;this.dispatchEvent(e);window.addEventListener("keypress",this.onKeypressBoundToThis_);window.addEventListener("keydown",this.onKeydownBoundToThis_)},onKeydown_:function(e){27==e.keyCode&&this.endTracing()},onKeypress_:function(e){"Enter"==e.keyIdentifier&&this.endTracing()},
+onClientInfoUpdate:function(e){this.clientInfo_=e},onGpuInfoUpdate:function(e){this.gpuInfo_=e},get isTracingEnabled(){return this.tracingEnabled_},get traceEvents(){return this.traceEvents_},onTraceDataCollected:function(e){this.statusDiv_.textContent="Processing trace...";this.traceEvents_.push.apply(this.traceEvents_,e)},endTracing:function(){if(!this.tracingEnabled_)throw Error("Tracing not begun.");this.tracingEnding_||(this.tracingEnding_=!0,this.statusDiv_.textContent="Ending trace...",console.log("Finishing trace"),
+this.statusDiv_.textContent="Downloading trace data...",this.stopButton_.hidden=!0,window.setTimeout(function(){chrome.send("endTracingAsync")},100))},onEndTracingComplete:function(){window.removeEventListener("keydown",this.onKeydownBoundToThis_);window.removeEventListener("keypress",this.onKeypressBoundToThis_);this.tracingEnding_=this.tracingEnabled_=this.overlay_.visible=!1;console.log("onEndTracingComplete p1 with "+this.traceEvents_.length+" events.");var e=new cr.Event("traceEnded");e.events=
+this.traceEvents_;this.dispatchEvent(e)},onSystemTraceDataCollected:function(e){console.log("onSystemTraceDataCollected with "+e.length+" chars of data.");this.systemTraceEvents_=e},get systemTraceEvents(){return this.systemTraceEvents_},beginLoadTraceFile:function(){chrome.send("loadTraceFile")},onLoadTraceFileComplete:function(e){e.traceEvents?this.traceEvents_=e.traceEvents:e.length?this.traceEvents_=e:console.log("Expected an array when loading the trace file");e.systemTraceEvents?this.systemTraceEvents_=
+e.systemTraceEvents:e.length?this.systemTraceEvents_=e:console.log("Expected an array when loading the trace file");e=new cr.Event("loadTraceFileComplete");e.events=this.traceEvents_;this.dispatchEvent(e)},onLoadTraceFileCanceled:function(){cr.dispatchSimpleEvent(this,"loadTraceFileCanceled")},beginSaveTraceFile:function(){chrome.send("saveTraceFile",[JSON.stringify({traceEvents:this.traceEvents_,systemTraceEvents:this.systemTraceEvents_,clientInfo:this.clientInfo_,gpuInfo:this.gpuInfo_})])},onSaveTraceFileComplete:function(){cr.dispatchSimpleEvent(this,
+"saveTraceFileComplete")},onSaveTraceFileCanceled:function(){cr.dispatchSimpleEvent(this,"saveTraceFileCanceled")},selfTest:function(){this.beginTracing();window.setTimeout(this.endTracing.bind(This),500)}};return{TracingController:g}});cr.define("tracing",function(){function g(a,b,d,c,f){this.title=a;this.start=d;this.colorId=b;this.args=c;this.didNotFinish=!1;void 0!==f&&(this.duration=f)}function e(a,b,d,c,f){g.call(this,a,b,d,c,f);this.subSlices=[]}function c(a,b,d,c){g.call(this,a,b,d,c)}function f(a,b){if(!a)throw"Parent must be provided.";this.parent=a;this.tid=b;this.subRows=[[]];this.asyncSlices=new d(this.ptid)}function h(a,b,d){this.parent=a;this.id=b;this.name=d;this.seriesNames=[];this.seriesColors=[];this.timestamps=
+[];this.samples=[]}function a(a){this.pid=a;this.threads={};this.counters={}}function b(a){this.cpuNumber=a;this.slices=[];this.counters={}}function d(a){this.name=a;this.slices=[]}function m(a){for(var b=0,d=0;d<a.length;++d)b=(b+37*b+11*a.charCodeAt(d))%4294967295;return b}function i(a,b){this.cpus={};this.processes={};this.importErrors=[];this.asyncSliceGroups={};a&&this.importEvents(a,b)}function j(){}function k(a){this.text_=a}g.prototype={selected:!1,duration:void 0,get end(){return this.start+
+this.duration}};e.prototype={__proto__:g.prototype};c.prototype={__proto__:g.prototype,id:void 0,startThread:void 0,endThread:void 0,subSlices:void 0};var l={};f.getPTIDFromPidAndTid=function(a,b){l[a]||(l[a]={});l[a][b]||(l[a][b]=a+":"+b);return l[a][b]};f.prototype={name:void 0,get ptid(){return f.getPTIDFromPidAndTid(this.tid,this.parent.pid)},getSubrow:function(a){for(;a>=this.subRows.length;)this.subRows.push([]);return this.subRows[a]},shiftSubRow_:function(a,b){for(var d=0;d<a.length;d++){var c=
+a[d];c.start+=b}},shiftTimestampsForward:function(a){this.cpuSlices&&this.shiftSubRow_(this.cpuSlices,a);for(var b=0;b<this.subRows.length;b++)this.shiftSubRow_(this.subRows[b],a);this.asyncSlices.shiftTimestampsForward(a)},updateBounds:function(){var a=[],b;0!=this.subRows[0].length&&(b=this.subRows[0],a.push(b[0].start),a.push(b[b.length-1].end));this.asyncSlices.slices.length&&(this.asyncSlices.updateBounds(),a.push(this.asyncSlices.minTimestamp),a.push(this.asyncSlices.maxTimestamp));a.length?
+(this.minTimestamp=Math.min.apply(Math,a),this.maxTimestamp=Math.max.apply(Math,a)):this.maxTimestamp=this.minTimestamp=void 0},get userFriendlyName(){return this.parent.pid+": "+(this.name||this.tid)},get userFriendlyDetails(){return"pid: "+this.parent.pid+", tid: "+this.tid+(this.name?", name: "+this.name:"")}};f.compare=function(b,d){if(b.parent.pid!=d.parent.pid)return a.compare(b.parent,d.parent.pid);if(b.name&&d.name){var c=b.name.localeCompare(d.name);return 0==c?b.tid-d.tid:c}return b.name?
+-1:d.name?1:b.tid-d.tid};h.prototype={__proto__:Object.prototype,get numSeries(){return this.seriesNames.length},get numSamples(){return this.timestamps.length},shiftTimestampsForward:function(a){for(var b=0;b<this.timestamps.length;b++)this.timestamps[b]+=a},updateBounds:function(){if(this.seriesNames.length!=this.seriesColors.length)throw"seriesNames.length must match seriesColors.length";if(this.numSeries*this.numSamples!=this.samples.length)throw"samples.length must be a multiple of numSamples.";
+this.totals=[];if(0==this.samples.length)this.maxTimestamp=this.minTimestamp=void 0,this.maxTotal=0;else{this.minTimestamp=this.timestamps[0];this.maxTimestamp=this.timestamps[this.timestamps.length-1];for(var a=this.numSeries,b=-Infinity,d=0;d<this.timestamps.length;d++){for(var c=0,f=0;f<a;f++)c+=this.samples[d*a+f],this.totals.push(c);c>b&&(b=c)}this.maxTotal=b}}};h.compare=function(b,d){if(b.parent.pid!=d.parent.pid)return a.compare(b.parent,d.parent.pid);var c=b.name.localeCompare(d.name);return 0==
+c?b.tid-d.tid:c};a.prototype={get numThreads(){var a=0,b;for(b in this.threads)a++;return a},shiftTimestampsForward:function(a){for(var b in this.threads)this.threads[b].shiftTimestampsForward(a);for(var d in this.counters)this.counters[d].shiftTimestampsForward(a)},getOrCreateThread:function(a){this.threads[a]||(this.threads[a]=new f(this,a));return this.threads[a]},getOrCreateCounter:function(a,b){var d=a+"."+b;this.counters[d]||(this.counters[d]=new h(this,d,b));return this.counters[d]}};a.compare=
+function(a,b){return a.pid-b.pid};b.prototype={getOrCreateCounter:function(a,b){var d;d=a.length?a+"."+b:b;this.counters[d]||(this.counters[d]=new h(this,d,b));return this.counters[d]},shiftTimestampsForward:function(a){for(var b=0;b<this.slices.length;b++)this.slices[b].start+=a;for(var d in this.counters)this.counters[d].shiftTimestampsForward(a)},updateBounds:function(){this.slices.length?(this.minTimestamp=this.slices[0].start,this.maxTimestamp=this.slices[this.slices.length-1].end):this.maxTimestamp=
+this.minTimestamp=void 0}};b.compare=function(a,b){return a.cpuNumber-b.cpuNumber};d.prototype={__proto__:Object.prototype,push:function(a){this.slices.push(a)},get length(){return this.slices.length},subRows_:void 0,sortSlices_:function(){this.slices.sort(function(a,b){return a.start-b.start})},shiftTimestampsForward:function(a){for(var b=0;b<this.slices.length;b++){var d=this.slices[b];d.start+=a;for(var c=0;c<d.subSlices.length;c++)d.subSlices[c].start+=a}},updateBounds:function(){this.sortSlices_();
+this.slices.length?(this.minTimestamp=this.slices[0].start,this.maxTimestamp=this.slices[this.slices.length-1].end):this.maxTimestamp=this.minTimestamp=void 0;this.subRows_=void 0},get subRows(){this.subRows_||this.rebuildSubRows_();return this.subRows_},rebuildSubRows_:function(){this.sortSlices_();for(var a=[],b=0;b<this.slices.length;b++){for(var d=this.slices[b],c=!1,f=0;f<a.length;f++){var e=a[f];if(d.start>=e[e.length-1].end){c=!0;if(void 0===d.subSlices||1>d.subSlices.length)throw"TimelineAsyncEvent missing subSlices: "+
+d.name;for(f=0;f<d.subSlices.length;f++)e.push(d.subSlices[f]);break}}if(!c&&(e=[],void 0!==d.subSlices)){for(f=0;f<d.subSlices.length;f++)e.push(d.subSlices[f]);a.push(e)}}this.subRows_=a},computeSubGroups:function(){for(var a={},b=0;b<this.slices.length;++b){var c=this.slices[b],f=c.startThread.ptid;a[f]||(a[f]=new d(this.name));a[f].slices.push(c)}var b=[],e;for(e in a)c=a[e],c.updateBounds(),b.push(c);return b}};h.compare=function(b,d){if(b.parent.pid!=d.parent.pid)return a.compare(b.parent,d.parent.pid);
+var c=b.name.localeCompare(d.name);return 0==c?b.tid-d.tid:c};var o=[{r:138,g:113,b:152},{r:175,g:112,b:133},{r:127,g:135,b:225},{r:93,g:81,b:137},{r:116,g:143,b:119},{r:178,g:214,b:122},{r:87,g:109,b:147},{r:119,g:155,b:95},{r:114,g:180,b:160},{r:132,g:85,b:103},{r:157,g:210,b:150},{r:148,g:94,b:86},{r:164,g:108,b:138},{r:139,g:191,b:150},{r:110,g:99,b:145},{r:80,g:129,b:109},{r:125,g:140,b:149},{r:93,g:124,b:132},{r:140,g:85,b:140},{r:104,g:163,b:162},{r:132,g:141,b:178},{r:131,g:105,b:147},{r:135,
+g:183,b:98},{r:152,g:134,b:177},{r:141,g:188,b:141},{r:133,g:160,b:210},{r:126,g:186,b:148},{r:112,g:198,b:205},{r:180,g:122,b:195},{r:203,g:144,b:152},{r:182,g:125,b:143},{r:126,g:200,b:148},{r:133,g:160,b:210},{r:240,g:240,b:240}],q=o.length-4,u=o.length,v=o.concat(o.map(function(a){var b;b=240<=a.r&&240<=a.g&&240<=a.b?-0.2:0.45;return{r:Math.min(255,a.r+Math.floor(a.r*b)),g:Math.min(255,a.g+Math.floor(a.g*b)),b:Math.min(255,a.b+Math.floor(a.b*b))}})).map(function(a){return"rgb("+a.r+","+a.g+","+
+a.b+")"}),t={},y=[];i.registerImporter=function(a){y.push(a)};j.canImport=function(a){return a instanceof Array&&0==a.length?!0:"string"===typeof a||a instanceof String?0==a.length:!1};j.prototype={__proto__:Object.prototype,importEvents:function(){},finalizeImport:function(){}};i.registerImporter(j);i.prototype={__proto__:cr.EventTarget.prototype,get numProcesses(){var a=0,b;for(b in this.processes)a++;return a},getOrCreateCpu:function(a){this.cpus[a]||(this.cpus[a]=new b(a));return this.cpus[a]},
+getOrCreateProcess:function(b){this.processes[b]||(this.processes[b]=new a(b));return this.processes[b]},pruneEmptyThreads:function(){for(var a in this.processes){var b=this.processes[a],d={},c;for(c in b.threads){for(var f=b.threads[c],e=!1,q=0;q<f.subRows.length;q++)e|=0<f.subRows[q].length;if(e||0<f.asyncSlices.length)d[c]=f}b.threads=d}},updateBounds:function(){for(var a=Infinity,b=-a,d=!1,c=this.getAllThreads(),f=0;f<c.length;f++){var e=c[f];e.updateBounds();void 0!=e.minTimestamp&&void 0!=e.maxTimestamp&&
+(a=Math.min(a,e.minTimestamp),b=Math.max(b,e.maxTimestamp),d=!0)}c=this.getAllCounters();for(f=0;f<c.length;f++)e=c[f],e.updateBounds(),void 0!=e.minTimestamp&&void 0!=e.maxTimestamp&&(d=!0,a=Math.min(a,e.minTimestamp),b=Math.max(b,e.maxTimestamp));for(var q in this.cpus)f=this.cpus[q],f.updateBounds(),void 0!=f.minTimestamp&&void 0!=f.maxTimestamp&&(d=!0,a=Math.min(a,f.minTimestamp),b=Math.max(b,f.maxTimestamp));d?(this.minTimestamp=a,this.maxTimestamp=b):this.minTimestamp=this.maxTimestamp=void 0},
+shiftWorldToZero:function(){if(void 0!==this.minTimestamp){var a=this.minTimestamp,b;for(b in this.processes)this.processes[b].shiftTimestampsForward(-a);for(var d in this.cpus)this.cpus[d].shiftTimestampsForward(-a);this.updateBounds()}},getAllThreads:function(){var a=[],b;for(b in this.processes){var d=this.processes[b],c;for(c in d.threads)a.push(d.threads[c])}return a},getAllCpus:function(){var a=[],b;for(b in this.cpus)a.push(this.cpus[b]);return a},getAllProcesses:function(){var a=[],b;for(b in this.processes)a.push(this.processes[b]);
+return a},getAllCounters:function(){var a=[],b;for(b in this.processes){var d=this.processes[b],c;for(c in d.counters)a.push(d.counters[c])}for(var f in this.cpus){b=this.cpus[f];for(var e in b.counters)a.push(b.counters[e])}return a},importOneTrace_:function(a,b){for(var d,c=0;c<y.length;++c)if(y[c].canImport(a)){d=y[c];break}if(!d)throw"Could not find an importer for the provided eventData.";d=new d(this,a,b);d.importEvents();return d},importEvents:function(a,b,d){void 0===b&&(b=!0);var c=[],a=
+this.importOneTrace_(a,!1);c.push(a);if(d)for(var f=0;f<d.length;++f)a=this.importOneTrace_(d[f],!0),c.push(a);for(f=0;f<c.length;++f)c[f].finalizeImport();for(f=0;f<c.length;++f)this.pruneEmptyThreads();this.updateBounds();b&&this.shiftWorldToZero();b&&(void 0!==this.minTimestamp&&void 0!==this.maxTimestamp)&&(b=0.15*(this.maxTimestamp-this.minTimestamp),this.minTimestamp-=b,this.maxTimestamp+=b)}};k.prototype={__proto__:Object.prototype,matchSlice:function(a){return 0==this.text_.length?!1:-1!=
+a.title.indexOf(this.text_)}};return{getPallette:function(){return v},getPalletteHighlightIdBoost:function(){return u},getColorIdByName:function(a){if("iowait"==a)return q;if("running"==a)return q+1;if("runnable"==a)return q+2;if("sleeping"==a)return q+3;throw"Unrecognized color "+a;},getStringHash:m,getStringColorId:function(a){if(void 0===t[a]){var b=m(a);t[a]=b%q}return t[a]},TimelineSlice:g,TimelineThreadSlice:e,TimelineAsyncSlice:c,TimelineThread:f,TimelineCounter:h,TimelineProcess:a,TimelineCpu:b,
+TimelineAsyncSliceGroup:d,TimelineModel:i,TimelineFilter:k}});cr.define("tracing",function(){function g(a){this.cpu=a}function e(){this.openSlices=[]}function c(a,b,d){this.isAdditionalImport_=d;this.model_=a;this.events_=b;this.clockSyncRecords_=[];this.cpuStates_={};this.kernelThreadStates_={};this.buildMapFromLinuxPidsToTimelineThreads();this.lineNumber=-1;this.threadStateByKPID_={}}g.prototype={__proto__:Object.prototype,switchRunningLinuxPid:function(a,b,d,c,f,e){if(void 0!==this.lastActivePid&&0!=this.lastActivePid){var h=d-this.lastActiveTs;name=(a=a.threadsByLinuxPid[this.lastActivePid])?
+a.userFriendlyName:this.lastActiveComm;this.cpu.slices.push(new tracing.TimelineSlice(name,tracing.getStringColorId(name),this.lastActiveTs,{comm:this.lastActiveComm,tid:this.lastActivePid,prio:this.lastActivePrio,stateWhenDescheduled:b},h))}this.lastActiveTs=d;this.lastActivePid=c;this.lastActiveComm=f;this.lastActivePrio=e}};TestExports={};var f=/^\s*(.+?)\s+\[(\d+)\]\s*([d.][N.][sh.][\d.])?\s*(\d+\.\d+):\s+(\S+):\s(.*)$/;TestExports.lineRE=f;var h=/trace_event_clock_sync: parent_ts=(\d+\.?\d*)/;
+TestExports.traceEventClockSyncRE=h;c.canImport=function(a){if(!("string"===typeof a||a instanceof String))return!1;if(/^# tracer:/.exec(a))return!0;var b=/^(.+)\n/.exec(a);b&&(a=b[1]);return f.exec(a)?!0:!1};c.prototype={__proto__:Object.prototype,buildMapFromLinuxPidsToTimelineThreads:function(){this.threadsByLinuxPid={};this.model_.getAllThreads().forEach(function(a){this.threadsByLinuxPid[a.tid]=a}.bind(this))},getOrCreateCpuState:function(a){if(!this.cpuStates_[a]){var b=this.model_.getOrCreateCpu(a);
+this.cpuStates_[a]=new g(b)}return this.cpuStates_[a]},parsePid:function(a){a=/.+-(\d+)/.exec(a)[1];return a=parseInt(a)},parseThreadName:function(a){return/(.+)-\d+/.exec(a)[1]},getOrCreateKernelThread:function(a,b,d){this.kernelThreadStates_[a]||(void 0==b&&(b=this.parsePid(a)),void 0==d&&(d=b),d=this.model_.getOrCreateProcess(b).getOrCreateThread(d),d.name=a,this.kernelThreadStates_[a]={pid:b,thread:d,openSlice:void 0,openSliceTS:void 0,asyncSlices:{}},this.threadsByLinuxPid[b]=d);return this.kernelThreadStates_[a]},
+importEvents:function(){this.importCpuData();this.alignClocks()&&this.buildPerThreadCpuSlicesFromCpuState()},finalizeImport:function(){},buildPerThreadCpuSlicesFromCpuState:function(){for(var a in this.cpuStates_)for(var b=this.cpuStates_[a].cpu,d=0;d<b.slices.length;d++){var c=b.slices[d],f=this.threadsByLinuxPid[c.args.tid];f&&(f.tempCpuSlices||(f.tempCpuSlices=[]),c.index=d,f.tempCpuSlices.push(c))}var e=tracing.getColorIdByName("running"),h=tracing.getColorIdByName("runnable"),g=tracing.getColorIdByName("sleeping"),
+o=tracing.getColorIdByName("iowait");this.model_.getAllThreads().forEach(function(a){if(a.tempCpuSlices){var b=a.tempCpuSlices;delete a.tempCpuSlices;b.sort(function(a,b){var d=a.start-b.start;return 0==d?a.index-b.index:d});var d=[];if(b.length){var c=b[0];d.push(new tracing.TimelineSlice("Running",e,c.start,{},c.duration))}for(c=1;c<b.length;c++){var f=b[c-1],m=b[c],i=m.start-f.end;if("S"==f.args.stateWhenDescheduled)d.push(new tracing.TimelineSlice("Sleeping",g,f.end,{},i));else if("R"==f.args.stateWhenDescheduled||
+"R+"==f.args.stateWhenDescheduled)d.push(new tracing.TimelineSlice("Runnable",h,f.end,{},i));else if("D"==f.args.stateWhenDescheduled)d.push(new tracing.TimelineSlice("Uninterruptible Sleep",o,f.end,{},i));else if("T"==f.args.stateWhenDescheduled)d.push(new tracing.TimelineSlice("__TASK_STOPPED",o,f.end,{},i));else if("t"==f.args.stateWhenDescheduled)d.push(new tracing.TimelineSlice("debug",o,f.end,{},i));else if("Z"==f.args.stateWhenDescheduled)d.push(new tracing.TimelineSlice("Zombie",o,f.end,{},
+i));else if("X"==f.args.stateWhenDescheduled)d.push(new tracing.TimelineSlice("Exit Dead",o,f.end,{},i));else if("x"==f.args.stateWhenDescheduled)d.push(new tracing.TimelineSlice("Task Dead",o,f.end,{},i));else if("W"==f.args.stateWhenDescheduled)d.push(new tracing.TimelineSlice("WakeKill",o,f.end,{},i));else if("D|W"==f.args.stateWhenDescheduled)d.push(new tracing.TimelineSlice("Uninterruptible Sleep | WakeKill",o,f.end,{},i));else throw"Unrecognized state: "+f.args.stateWhenDescheduled;d.push(new tracing.TimelineSlice("Running",
+e,m.start,{},m.duration))}a.cpuSlices=d}})},alignClocks:function(){if(0==this.clockSyncRecords_.length){if(!this.isAdditionalImport_)return;this.abortImport();return!1}var a=this.clockSyncRecords_[0];if(0==a.parentTS||a.parentTS==a.perfTS)return!0;var a=a.parentTS-a.perfTS,b;for(b in this.cpuStates_){for(var d=this.cpuStates_[b].cpu,c=0;c<d.slices.length;c++){var f=d.slices[c];f.start+=a;f.duration=f.duration}for(var e in d.counters){c=d.counters[e];for(f=0;f<c.timestamps.length;f++)c.timestamps[f]+=
+a}}for(var h in this.kernelThreadStates_){b=this.kernelThreadStates_[h].thread;for(c=0;c<b.subRows[0].length;c++)b.subRows[0][c].start+=a}return!0},abortImport:function(){if(this.pushedEventsToThreads)throw"Cannot abort, have alrady pushedCpuDataToThreads.";for(var a in this.cpuStates_)delete this.model_.cpus[a];for(var b in this.kernelThreadStates_){a=this.kernelThreadStates_[b].thread;var d=a.parent;delete d.threads[a.tid];delete this.model_.processes[d.pid]}this.model_.importErrors.push("Cannot import kernel trace without a clock sync.")},
+markPidRunnable:function(){},importError:function(a){this.model_.importErrors.push("Line "+(this.lineNumber+1)+": "+a)},malformedEvent:function(a){this.importError("Malformed "+a+" event")},openSlice:function(a,b,d){a.openSliceTS=d;a.openSlice=b},closeSlice:function(a,b,d){a.openSlice&&(b=new tracing.TimelineSlice(a.openSlice,tracing.getStringColorId(a.openSlice),a.openSliceTS,d,b-a.openSliceTS),a.thread.subRows[0].push(b),a.openSlice=void 0)},openAsyncSlice:function(a,b,d,c){d=new tracing.TimelineAsyncSlice(c,
+tracing.getStringColorId(c),d);d.startThread=a.thread;a.asyncSlices[b]=d},closeAsyncSlice:function(a,b,d,c){var f=a.asyncSlices[b];f&&(f.duration=d-f.start,f.args=c,f.endThread=a.thread,f.subSlices=[new tracing.TimelineSlice(f.title,f.colorId,f.start,f.args,f.duration)],a.thread.asyncSlices.push(f),delete a.asyncSlices[b])},getThreadState:function(a){return this.threadStateByKPID_[this.parsePid(a)]},getOrCreateThreadState:function(a,b){var d=this.parsePid(a),c=this.threadStateByKPID_[d];c||(c=new e,
+c.threadName=this.parseThreadName(a),c.tid=d,c.pid=b,c.thread=this.model_.getOrCreateProcess(b).getOrCreateThread(d),this.threadsByLinuxPid[d]=c.thread,c.thread.name||(c.thread.name=c.threadName),this.threadStateByKPID_[d]=c);return c},processBegin:function(a,b,d,c){a=this.getOrCreateThreadState(a,c);c=tracing.getStringColorId(b);b=new tracing.TimelineThreadSlice(b,c,d,null);a.openSlices.push(b)},processEnd:function(a,b){var d=this.getThreadState(a);if(d&&0!=d.openSlices.length){var c=d.openSlices.pop();
+c.duration=b-c.start;d.thread.getSubrow(d.openSlices.length).push(c);d.openSlices.length&&d.openSlices[d.openSlices.length-1].subSlices.push(c)}},autoCloseOpenSlices:function(){this.model_.updateBounds();var a=[],b;for(b in this.threadStateByKPID_)for(var d=this.threadStateByKPID_[b],c=0;c<d.openSlices.length;c++){var f=d.openSlices[c];a.push(f.start);for(var e=0;e<f.subSlices.length;e++){var h=f.subSlices[e];a.push(h.start);h.duration&&a.push(h.end)}}a=this.model_.maxTimestamp?Math.max(this.model_.maxTimestamp,
+Math.max.apply(Math,a)):Math.max.apply(Math,a);for(b in this.threadStateByKPID_)for(d=this.threadStateByKPID_[b];0<d.openSlices.length;)f=d.openSlices.pop(),f.duration=a-f.start,f.didNotFinish=!0,d.thread.getSubrow(d.openSlices.length).push(f),d.openSlices.length&&d.openSlices[d.openSlices.length-1].subSlices.push(f)},processCounter:function(a,b,d,c){a=this.model_.getOrCreateProcess(c).getOrCreateCounter("",a);0==a.numSeries&&(a.seriesNames.push("state"),a.seriesColors.push(tracing.getStringColorId(a.name+
+".state")));a.timestamps.push(b);a.samples.push(d)},importCpuData:function(){this.lines_=this.events_.split("\n");for(this.lineNumber=0;this.lineNumber<this.lines_.length;++this.lineNumber){var a=this.lines_[this.lineNumber];if(!(/^#/.exec(a)||0==a.length)){var b=f.exec(a);if(b){var a=b[1],d=b[2],c=b[4],e=b[5],b=b[6],h=this.eventDefinitions[e];if(h){var g;if(h.format){if(g=h.format.exec(b),!g){this.malformedEvent(e);continue}}else g={};g.timestamp=1E3*parseFloat(c);g.name=e;g.info=b;g.taskId=a;g.cpuState=
+this.getOrCreateCpuState(parseInt(d));h.handler&&h.handler(this,g)}else console.log("unknown event "+e)}else this.importError("Unrecognized line: "+a)}}},eventDefinitions:{sched_switch:{format:RegExp("prev_comm=(.+) prev_pid=(\\d+) prev_prio=(\\d+) prev_state=(\\S+) ==> next_comm=(.+) next_pid=(\\d+) next_prio=(\\d+)"),handler:function(a,b){var d=b[4],c=b[5],f=parseInt(b[6]),e=parseInt(b[7]);b.cpuState.switchRunningLinuxPid(a,d,b.timestamp,f,c,e)}},sched_wakeup:{format:/comm=(.+) pid=(\d+) prio=(\d+) success=(\d+) target_cpu=(\d+)/,
+handler:function(a,b){var d=b[1],c=parseInt(b[2]),f=parseInt(b[3]);a.markPidRunnable(b.timestamp,c,d,f)}},power_start:{format:/type=(\d+) state=(\d) cpu_id=(\d)+/,handler:function(a,b){var d=parseInt(b[3]),d=a.getOrCreateCpuState(d);if("1"==b[1]){d=d.cpu.getOrCreateCounter("","C-State");0==d.numSeries&&(d.seriesNames.push("state"),d.seriesColors.push(tracing.getStringColorId(d.name+".state")));var c=parseInt(b[2]);d.timestamps.push(b.timestamp);d.samples.push(c)}else a.importError("Don't understand power_start events of type "+
+b[1])}},power_frequency:{format:/type=(\d+) state=(\d+) cpu_id=(\d)+/,handler:function(a,b){var d=parseInt(b[3]),d=a.getOrCreateCpuState(d).cpu.getOrCreateCounter("","Power Frequency");0==d.numSeries&&(d.seriesNames.push("state"),d.seriesColors.push(tracing.getStringColorId(d.name+".state")));var c=parseInt(b[2]);d.timestamps.push(b.timestamp);d.samples.push(c)}},cpu_frequency:{format:/state=(\d+) cpu_id=(\d)+/,handler:function(a,b){var d=parseInt(b[2]),d=a.getOrCreateCpuState(d).cpu.getOrCreateCounter("",
+"Clock Frequency");0==d.numSeries&&(d.seriesNames.push("state"),d.seriesColors.push(tracing.getStringColorId(d.name+".state")));var c=parseInt(b[1]);d.timestamps.push(b.timestamp);d.samples.push(c)}},cpu_idle:{format:/state=(\d+) cpu_id=(\d)+/,handler:function(a,b){var d=parseInt(b[2]),d=a.getOrCreateCpuState(d).cpu.getOrCreateCounter("","C-State");0==d.numSeries&&(d.seriesNames.push("state"),d.seriesColors.push(tracing.getStringColorId(d.name)));var c=parseInt(b[1]);4294967295!=c?d.samples.push(c):
+d.samples.push(0);d.timestamps.push(b.timestamp)}},workqueue_execute_start:{format:/work struct (.+): function (\S+)/,handler:function(a,b){var d=a.getOrCreateKernelThread(b.taskId);a.openSlice(d,b[2],b.timestamp)}},workqueue_execute_end:{format:/work struct (.+)/,handler:function(a,b){var d=a.getOrCreateKernelThread(b.taskId);a.closeSlice(d,b.timestamp,{})}},workqueue_queue_work:{},workqueue_activate_work:{},ext4_sync_file_enter:{format:/dev (\d+,\d+) ino (\d+) parent (\d+) datasync (\d+)/,handler:function(a,
+b){var d=a.getOrCreateKernelThread("ext4:"+b.taskId);a.openAsyncSlice(d,b[1]+"-"+b[2],b.timestamp,1==b[4]?"fdatasync":"fsync")}},ext4_sync_file_exit:{format:/dev (\d+,\d+) ino (\d+) ret (\d+)/,handler:function(a,b){var d=a.getOrCreateKernelThread("ext4:"+b.taskId),c=b[1],f=b[2],e=parseInt(b[3]);a.closeAsyncSlice(d,c+"-"+f,b.timestamp,{device:c,inode:f,error:e})}},block_rq_issue:{format:/(\d+,\d+) (F)?([DWRN])(F)?(A)?(S)?(M)? \d+ \(.*\) (\d+) \+ (\d+) \[.*\]/,handler:function(a,b){var d;switch(b[3]){case "D":d=
+"discard";break;case "W":d="write";break;case "R":d="read";break;case "N":d="none";break;default:d="unknown"}b[2]&&(d+=" flush");"F"==b[4]&&(d+=" fua");"A"==b[5]&&(d+=" ahead");"S"==b[6]&&(d+=" sync");"M"==b[7]&&(d+=" meta");var c=b[1],f=parseInt(b[8]),e=parseInt(b[9]),h=a.getOrCreateKernelThread("block:"+b.taskId);a.openAsyncSlice(h,c+"-"+f+"-"+e,b.timestamp,d)}},block_rq_complete:{format:/(\d+,\d+) (F)?([DWRN])(F)?(A)?(S)?(M)? \(.*\) (\d+) \+ (\d+) \[(.*)\]/,handler:function(a,b){var d=b[1],c=parseInt(b[8]),
+f=parseInt(b[9]),e=parseInt(b[10]),h=a.getOrCreateKernelThread("block:"+b.taskId);a.closeAsyncSlice(h,d+"-"+c+"-"+f,b.timestamp,{device:d,sector:c,numSectors:f,error:e})}},i915_gem_object_pwrite:{format:/obj=(.+), offset=(\d+), len=(\d+)/,handler:function(a,b){var d=b[1],c=parseInt(b[2]),f=parseInt(b[3]),e=a.getOrCreateKernelThread("i915_gem",0,1);a.openSlice(e,"pwrite:"+d,b.timestamp);a.closeSlice(e,b.timestamp,{obj:d,offset:c,len:f})}},i915_flip_request:{format:/plane=(\d+), obj=(.+)/,handler:function(a,
+b){var d=parseInt(b[1]),c=b[2],f=a.getOrCreateKernelThread("i915_flip",0,2);a.openSlice(f,"flip:"+c+"/"+d,b.timestamp)}},i915_flip_complete:{format:/plane=(\d+), obj=(.+)/,handler:function(a,b){var d=parseInt(b[1]),c=b[2],f=a.getOrCreateKernelThread("i915_flip",0,2);a.closeSlice(f,b.timestamp,{obj:c,plane:d})}},tracing_mark_write:{handler:function(a,b){var d=h.exec(b.info);if(d)a.clockSyncRecords_.push({perfTS:b.timestamp,parentTS:1E3*d[1]});else switch(d=b.info.split("|"),d[0]){case "B":var c=parseInt(d[1]),
+f=d[2];a.processBegin(b.taskId,f,b.timestamp,c);break;case "E":a.processEnd(b.taskId,b.timestamp);break;case "C":c=parseInt(d[1]);f=d[2];d=parseInt(d[3]);a.processCounter(f,b.timestamp,d,c);break;default:a.malformedEvent(b.name)}}}}};c.prototype.eventDefinitions["0"]=c.prototype.eventDefinitions.tracing_mark_write;TestExports.eventDefinitions=c.prototype.eventDefinitions;tracing.TimelineModel.registerImporter(c);return{LinuxPerfImporter:c,_LinuxPerfImporterTestExports:TestExports}});cr.define("tracing",function(){function g(){this.openSlices=[]}function e(c,f){this.model_=c;"string"===typeof f||f instanceof String?("["==f[0]&&(n=f.length,"]"!=f[n-1]&&"\n"!=f[n-1]?f+="]":"]"!=f[n-2]&&"\n"==f[n-1]?f+="]":"]"!=f[n-3]&&("\r"==f[n-2]&&"\n"==f[n-1])&&(f+="]")),this.events_=JSON.parse(f)):this.events_=f;this.events_.traceEvents&&(this.events_=this.events_.traceEvents);this.threadStateByPTID_={};this.allAsyncEvents_=[]}e.canImport=function(c){return"string"===typeof c||c instanceof String?
+"{"==c[0]||"["==c[0]:c instanceof Array&&c.length&&c[0].ph?!0:c.traceEvents?c.traceEvents instanceof Array&&c.traceEvents[0].ph:!1};e.prototype={__proto__:Object.prototype,processBeginEvent:function(c,f,e){var a=tracing.getStringColorId(e.name),c={index:c,slice:new tracing.TimelineThreadSlice(e.name,a,e.ts/1E3,e.args)};e.uts&&(c.slice.startInUserTime=e.uts/1E3);"0"===e.args["ui-nest"]?this.model_.importErrors.push("ui-nest no longer supported."):f.openSlices.push(c)},processEndEvent:function(c,f){if("0"===
+f.args["ui-nest"])this.model_.importErrors.push("ui-nest no longer supported.");else if(0!=c.openSlices.length){var e=c.openSlices.pop().slice;e.duration=f.ts/1E3-e.start;f.uts&&(e.durationInUserTime=f.uts/1E3-e.startInUserTime);for(var a in f.args)e.args[a]=f.args[a];this.model_.getOrCreateProcess(f.pid).getOrCreateThread(f.tid).getSubrow(c.openSlices.length).push(e);c.openSlices.length&&c.openSlices[c.openSlices.length-1].slice.subSlices.push(e)}},processAsyncEvent:function(c,f,e){c=this.model_.getOrCreateProcess(e.pid).getOrCreateThread(e.tid);
+this.allAsyncEvents_.push({event:e,thread:c})},autoCloseOpenSlices:function(){this.model_.updateBounds();var c=[],f;for(f in this.threadStateByPTID_)for(var e=this.threadStateByPTID_[f],a=0;a<e.openSlices.length;a++){var b=e.openSlices[a];c.push(b.slice.start);for(var d=0;d<b.slice.subSlices.length;d++){var g=b.slice.subSlices[d];c.push(g.start);g.duration&&c.push(g.end)}}c=this.model_.maxTimestamp?Math.max(this.model_.maxTimestamp,Math.max.apply(Math,c)):Math.max.apply(Math,c);for(f in this.threadStateByPTID_)for(e=
+this.threadStateByPTID_[f];0<e.openSlices.length;)b=e.openSlices.pop(),b.slice.duration=c-b.slice.start,b.slice.didNotFinish=!0,a=this.events_[b.index],this.model_.getOrCreateProcess(a.pid).getOrCreateThread(a.tid).getSubrow(e.openSlices.length).push(b.slice),e.openSlices.length&&e.openSlices[e.openSlices.length-1].slice.subSlices.push(b.slice)},processCounterEvent:function(c){var f;f=void 0!==c.id?c.name+"["+c.id+"]":c.name;f=this.model_.getOrCreateProcess(c.pid).getOrCreateCounter(c.cat,f);if(0==
+f.numSeries){for(var e in c.args)f.seriesNames.push(e),f.seriesColors.push(tracing.getStringColorId(f.name+"."+e));if(0==f.numSeries){this.model_.importErrors.push("Expected counter "+c.name+" to have at least one argument to use as a value.");delete f.parent.counters[f.name];return}}f.timestamps.push(c.ts/1E3);for(var a=0;a<f.numSeries;a++)e=f.seriesNames[a],void 0===c.args[e]?f.samples.push(0):f.samples.push(c.args[e])},importEvents:function(){for(var c=this.events_,f=0;f<c.length;f++){var e=c[f],
+a=tracing.TimelineThread.getPTIDFromPidAndTid(e.pid,e.tid);a in this.threadStateByPTID_||(this.threadStateByPTID_[a]=new g);var b=this.threadStateByPTID_[a];"B"==e.ph?this.processBeginEvent(f,b,e):"E"==e.ph?this.processEndEvent(b,e):"S"==e.ph?this.processAsyncEvent(f,b,e):"F"==e.ph?this.processAsyncEvent(f,b,e):"T"==e.ph?this.processAsyncEvent(f,b,e):"I"==e.ph?(this.processBeginEvent(f,b,e),this.processEndEvent(b,e)):"C"==e.ph?this.processCounterEvent(e):"M"==e.ph?"thread_name"==e.name?this.model_.getOrCreateProcess(e.pid).getOrCreateThread(e.tid).name=
+e.args.name:this.model_.importErrors.push("Unrecognized metadata name: "+e.name):this.model_.importErrors.push("Unrecognized event phase: "+e.ph+"("+e.name+")")}c=!1;for(a in this.threadStateByPTID_)b=this.threadStateByPTID_[a],c|=0<b.openSlices.length;c&&this.autoCloseOpenSlices()},finalizeImport:function(){if(0!=this.allAsyncEvents_.length){this.allAsyncEvents_.sort(function(a,b){return a.event.ts-b.event.ts});for(var c={},f=this.allAsyncEvents_,e=0;e<f.length;e++){var a=f[e],b=a.event,d=b.name;
+if(void 0===d)this.model_.importErrors.push("Async events (ph: S, T or F) require an name parameter.");else{var g=b.id;if(void 0===g)this.model_.importErrors.push("Async events (ph: S, T or F) require an id parameter.");else if("S"==b.ph)void 0===c[d]&&(c[d]={}),c[d][g]?this.model_.importErrors.push("At "+b.ts+", an slice of the same id "+g+" was alrady open."):(c[d][g]=[],c[d][g].push(a));else if(void 0===c[d])this.model_.importErrors.push("At "+b.ts+", no slice named "+d+" was open.");else if(void 0===
+c[d][g])this.model_.importErrors.push("At "+b.ts+", no slice named "+d+" with id="+g+" was open.");else{var i=c[d][g];i.push(a);if("F"==b.ph){var j=new tracing.TimelineAsyncSlice(d,tracing.getStringColorId(d),i[0].event.ts/1E3);j.duration=b.ts/1E3-i[0].event.ts/1E3;j.startThread=i[0].thread;j.endThread=a.thread;j.id=g;j.args=i[0].event.args;j.subSlices=[];for(a=1;a<i.length;++a){var k=d;"T"==i[a-1].event.ph&&(k=d+":"+i[a-1].event.args.step);k=new tracing.TimelineAsyncSlice(k,tracing.getStringColorId(d+
+a),i[a-1].event.ts/1E3);k.duration=i[a].event.ts/1E3-i[a-1].event.ts/1E3;k.startThread=i[a-1].thread;k.endThread=i[a].thread;k.id=g;k.args=i[a-1].event.args;j.subSlices.push(k)}var i=j.subSlices[j.subSlices.length-1],l;for(l in b.args)i.args[l]=b.args[l];j.startThread.asyncSlices.push(j);delete c[d][g]}}}}}}};tracing.TimelineModel.registerImporter(e);return{TraceEventImporter:e}});cr.define("tracing",function(){function g(c,f,e){if(0==c.length)return 1;for(var a=0,b=c.length-1,d,g,i=-1;a<=b;)d=Math.floor((a+b)/2),g=f(c[d])-e,0>g?a=d+1:(0<g||(i=d),b=d-1);return-1!=i?i:a}function e(c,f,e,a,b,d){if(!(a>b)){var m=g(c,f,a);if(-1!=m&&(0<m&&f(c[m-1])+e(c[m-1])>=a&&d(c[m-1]),m!=c.length))for(e=c.length;m<e&&!(f(c[m])>=b);m++)d(c[m])}}return{findLowIndexInSortedArray:g,findLowIndexInSortedIntervals:function(c,f,e,a){var b=g(c,f,a);return 0==b?a>=f(c[0])&&a<f(c[0]+e(c[0]))?0:-1:b<=c.length&&
+a>=f(c[b-1])&&a<f(c[b-1])+e(c[b-1])?b-1:c.length},iterateOverIntersectingIntervals:e,getIntersectingIntervals:function(c,f,g,a,b){var d=[];e(c,f,g,a,b,function(a){d.push(a)});return d}}});cr.define("tracing",function(){function g(){var e=document.createElement("iframe");e.style.cssText="width:100%;height:0;border:0;visibility:hidden";document.body.appendChild(e);this._doc=e.contentDocument;this._window=e.contentWindow;this._doc.body.style.cssText="padding:0;margin:0;overflow:hidden";for(var e=document.querySelectorAll("link[rel=stylesheet]"),c=0;c<e.length;c++){var f=e[c],g=this._doc.createElement("link");g.rel="stylesheet";g.href=f.href;this._doc.head.appendChild(g)}}g.prototype=
+{__proto__:Object.prototype,measure:function(e){this._doc.body.appendChild(e);var c=this._window.getComputedStyle(e),f=parseInt(c.width,10),c=parseInt(c.height,10);this._doc.body.removeChild(e);return{width:f,height:c}}};return{MeasuringStick:g}});cr.define("tracing",function(){function g(a){this.parentEl_=a;this.scaleX_=1;this.gridTimebase_=this.panX_=0;this.gridStep_=1E3/60;this.hasCalledSetupFunction_=this.gridEnabled_=!1;this.onResizeBoundToThis_=this.onResize_.bind(this);this.checkForAttachInterval_=setInterval(this.checkForAttach_.bind(this),250)}function e(a,b){this.track=a;this.slice=b}function c(a,b,d){this.track=a;this.counter=b;this.sampleIndex=d}function f(){this.range_dirty_=!0;this.range_={};this.length_=0}g.prototype={__proto__:cr.EventTarget.prototype,
+setWhenPossible:function(a){this.pendingSetFunction_=a},get isAttachedToDocument_(){for(var a=this.parentEl_;a.parentNode;)a=a.parentNode;return a==this.parentEl_.ownerDocument},onResize_:function(){this.dispatchChangeEvent()},checkForAttach_:function(){if(this.isAttachedToDocument_&&0!=this.clientWidth){this.iframe_||(this.iframe_=document.createElement("iframe"),this.iframe_.style.cssText="position:absolute;width:100%;height:0;border:0;visibility:hidden;",this.parentEl_.appendChild(this.iframe_),
+this.iframe_.contentWindow.addEventListener("resize",this.onResizeBoundToThis_));var a=this.clientWidth+"x"+this.clientHeight;this.pendingSetFunction_&&(this.lastSize_=a,this.pendingSetFunction_(),this.pendingSetFunction_=void 0);window.clearInterval(this.checkForAttachInterval_);this.checkForAttachInterval_=void 0}},dispatchChangeEvent:function(){cr.dispatchSimpleEvent(this,"change")},detach:function(){this.checkForAttachInterval_&&(window.clearInterval(this.checkForAttachInterval_),this.checkForAttachInterval_=
+void 0);this.iframe_.removeEventListener("resize",this.onResizeBoundToThis_);this.parentEl_.removeChild(this.iframe_)},get scaleX(){return this.scaleX_},set scaleX(a){this.scaleX_!=a&&(this.scaleX_=a,this.dispatchChangeEvent())},get panX(){return this.panX_},set panX(a){this.panX_!=a&&(this.panX_=a,this.dispatchChangeEvent())},setPanAndScale:function(a,b){if(this.scaleX_!=b||this.panX_!=a)this.scaleX_=b,this.panX_=a,this.dispatchChangeEvent()},xWorldToView:function(a){return(a+this.panX_)*this.scaleX_},
+xWorldVectorToView:function(a){return a*this.scaleX_},xViewToWorld:function(a){return a/this.scaleX_-this.panX_},xViewVectorToWorld:function(a){return a/this.scaleX_},xPanWorldPosToViewPos:function(a,b,d){if("string"==typeof b)if("left"==b)b=0;else if("center"==b)b=d/2;else if("right"==b)b=d-1;else throw Error("unrecognized string for viewPos. left|center|right");this.panX=b/this.scaleX_-a},xPanWorldRangeIntoView:function(a,b,d){0>this.xWorldToView(a)?this.xPanWorldPosToViewPos(a,"left",d):this.xWorldToView(b)>
+d&&this.xPanWorldPosToViewPos(b,"right",d)},xSetWorldRange:function(a,b,d){this.setPanAndScale(-a,d/(b-a))},get gridEnabled(){return this.gridEnabled_},set gridEnabled(a){this.gridEnabled_!=a&&(this.gridEnabled_=a&&!0,this.dispatchChangeEvent())},get gridTimebase(){return this.gridTimebase_},set gridTimebase(a){this.gridTimebase_!=a&&(this.gridTimebase_=a,cr.dispatchSimpleEvent(this,"change"))},get gridStep(){return this.gridStep_},applyTransformToCanavs:function(a){a.transform(this.scaleX_,0,0,1,
+this.panX_*this.scaleX_,0)}};e.prototype={get selected(){return this.slice.selected},set selected(a){this.slice.selected=a}};c.prototype={get selected(){return!0==this.track.selectedSamples[this.sampleIndex]},set selected(a){this.track.selectedSamples[this.sampleIndex]=a?!0:!1;this.track.invalidate()}};f.prototype={__proto__:Object.prototype,get range(){if(this.range_dirty_){for(var a=Infinity,b=-a,d=0;d<this.length_;d++){var c=this[d];c.slice&&(a=Math.min(a,c.slice.start),b=Math.max(b,c.slice.end))}this.range_=
+{min:a,max:b};this.range_dirty_=!1}return this.range_},get duration(){return this.range.max-this.range.min},get length(){return this.length_},clear:function(){for(var a=0;a<this.length_;++a)delete this[a];this.length_=0;this.range_dirty_=!0},push_:function(a){this[this.length_++]=a;this.range_dirty_=!0;return a},addSlice:function(a,b){return this.push_(new e(a,b))},addCounterSample:function(a,b,d){return this.push_(new c(a,b,d))},subSelection:function(a,b){var b=b||1,d=new f;d.range_dirty_=!0;if(0>
+a||a+b>this.length_)throw"Index out of bounds";for(var c=a;c<a+b;c++)d.push_(this[c]);return d},getCounterSampleHits:function(){for(var a=new f,b=0;b<this.length_;b++)this[b]instanceof c&&a.push_(this[b]);return a},getSliceHits:function(){for(var a=new f,b=0;b<this.length_;b++)this[b]instanceof e&&a.push_(this[b]);return a},map:function(a){for(var b=0;b<this.length_;b++)a(this[b])},getShiftedSelection:function(a){for(var b=new f,d=0;d<this.length_;d++){var c=this[d];c.track.addItemNearToProvidedHitToSelection(c,
+a,b)}return 0==b.length?void 0:b}};var h=cr.ui.define("div");h.prototype={__proto__:HTMLDivElement.prototype,model_:null,decorate:function(){this.classList.add("timeline");this.viewport_=new g(this);this.viewportTrack=new tracing.TimelineViewportTrack;this.tracks_=this.ownerDocument.createElement("div");this.appendChild(this.tracks_);this.dragBox_=this.ownerDocument.createElement("div");this.dragBox_.className="timeline-drag-box";this.appendChild(this.dragBox_);this.hideDragBox_();this.bindEventListener_(document,
+"keypress",this.onKeypress_,this);this.bindEventListener_(document,"keydown",this.onKeydown_,this);this.bindEventListener_(document,"mousedown",this.onMouseDown_,this);this.bindEventListener_(document,"mousemove",this.onMouseMove_,this);this.bindEventListener_(document,"mouseup",this.onMouseUp_,this);this.bindEventListener_(document,"dblclick",this.onDblClick_,this);this.lastMouseViewPos_={x:0,y:0};this.selection_=new f},bindEventListener_:function(a,b,d,c){this.boundListeners_||(this.boundListeners_=
+[]);d=d.bind(c);this.boundListeners_.push({object:a,event:b,boundFunc:d});a.addEventListener(b,d)},detach:function(){for(var a=0;a<this.tracks_.children.length;a++)this.tracks_.children[a].detach();for(a=0;a<this.boundListeners_.length;a++){var b=this.boundListeners_[a];b.object.removeEventListener(b.event,b.boundFunc)}this.boundListeners_=void 0;this.viewport_.detach()},get viewport(){return this.viewport_},get model(){return this.model_},set model(a){if(!a)throw Error("Model cannot be null");if(this.model)throw Error("Cannot set model twice.");
+this.model_=a;var b=[];a.getAllThreads().forEach(function(a){b.push(a.userFriendlyName)});a.getAllCounters().forEach(function(a){b.push(a.name)});a.getAllCpus().forEach(function(a){b.push("CPU "+a.cpuNumber)});var d=0,c=new tracing.MeasuringStick,f=document.createElement("div");f.style.position="fixed";f.className="timeline-canvas-based-track-title";b.forEach(function(a){f.textContent=a+":__";a=c.measure(f).width;300<a&&(a=300);a>d&&(d=a)});for(var d=d+"px",e=0;e<this.tracks_.children.length;e++)this.tracks_.children[e].detach();
+this.tracks_.textContent="";this.viewportTrack.headingWidth=d;this.viewportTrack.viewport=this.viewport_;e=a.getAllCpus();e.sort(tracing.TimelineCpu.compare);e.forEach(function(a){var b=new tracing.TimelineCpuTrack;b.heading="CPU "+a.cpuNumber+":";b.headingWidth=d;b.viewport=this.viewport_;b.cpu=a;this.tracks_.appendChild(b);for(var c in a.counters){var f=a.counters[c],b=new tracing.TimelineCounterTrack;b.heading="CPU "+a.cpuNumber+" "+f.name+":";b.headingWidth=d;b.viewport=this.viewport_;b.counter=
+f;this.tracks_.appendChild(b)}}.bind(this));a=a.getAllProcesses();a.sort(tracing.TimelineProcess.compare);a.forEach(function(a){var b=[],c;for(c in a.counters)b.push(a.counters[c]);b.sort(tracing.TimelineCounter.compare);b.forEach(function(a){var b=new tracing.TimelineCounterTrack;b.heading=a.name+":";b.headingWidth=d;b.viewport=this.viewport_;b.counter=a;this.tracks_.appendChild(b)}.bind(this));b=[];for(c in a.threads)b.push(a.threads[c]);b.sort(tracing.TimelineThread.compare);b.forEach(function(a){var b=
+new tracing.TimelineThreadTrack;b.heading=a.userFriendlyName+":";b.tooltip=a.userFriendlyDetails;b.headingWidth=d;b.viewport=this.viewport_;b.thread=a;this.tracks_.appendChild(b)}.bind(this))}.bind(this));this.viewport_.setWhenPossible(function(){this.viewport_.xSetWorldRange(this.model_.minTimestamp,this.model_.maxTimestamp,this.firstCanvas.width)}.bind(this))},addAllObjectsMatchingFilterToSelection:function(a,b){for(var d=0;d<this.tracks_.children.length;++d)this.tracks_.children[d].addAllObjectsMatchingFilterToSelection(a,
+b)},get focusElement(){return this.focusElement_?this.focusElement_:this.parentElement},set focusElement(a){this.focusElement_=a},get listenToKeys_(){return!this.viewport_.isAttachedToDocument_?!1:!this.focusElement_?!0:0<=this.focusElement.tabIndex?document.activeElement==this.focusElement:!0},onKeypress_:function(a){var b=this.viewport_;if(this.firstCanvas&&this.listenToKeys_){var d=this.firstCanvas.clientWidth;switch(a.keyCode){case 101:a=b.xViewToWorld(this.lastMouseViewPos_.x);b.xPanWorldPosToViewPos(a,
+"center",d);break;case 119:this.zoomBy_(1.5);break;case 115:this.zoomBy_(1/1.5);break;case 103:this.onGridToggle_(!0);break;case 71:this.onGridToggle_(!1);break;case 87:this.zoomBy_(10);break;case 83:this.zoomBy_(0.1);break;case 97:b.panX+=b.xViewVectorToWorld(0.1*d);break;case 100:b.panX-=b.xViewVectorToWorld(0.1*d);break;case 65:b.panX+=b.xViewVectorToWorld(0.5*d);break;case 68:b.panX-=b.xViewVectorToWorld(0.5*d)}}},onKeydown_:function(a){if(this.listenToKeys_){var b;switch(a.keyCode){case 37:if(b=
+this.selection.getShiftedSelection(-1))this.setSelectionAndMakeVisible(b),a.preventDefault();break;case 39:if(b=this.selection.getShiftedSelection(1))this.setSelectionAndMakeVisible(b),a.preventDefault();break;case 9:-1==this.focusElement.tabIndex&&(a.shiftKey?this.selectPrevious_(a):this.selectNext_(a),a.preventDefault())}}},zoomBy_:function(a){if(this.firstCanvas){var b=this.viewport_,d=this.firstCanvas.clientWidth,c=this.lastMouseViewPos_.x,f=b.xViewToWorld(c);b.scaleX*=a;b.xPanWorldPosToViewPos(f,
+c,d)}},get keyHelp(){var a="Keyboard shortcuts:\n w/s     : Zoom in/out    (with shift: go faster)\n a/d     : Pan left/right\n e       : Center on mouse\n g/G     : Shows grid at the start/end of the selected task\n",a=this.focusElement.tabIndex?a+" <-      : Select previous event on current timeline\n ->      : Select next event on current timeline\n":a+" <-,^TAB : Select previous event on current timeline\n ->, TAB : Select next event on current timeline\n";return a+"\nDbl-click to zoom in; Shift dbl-click to zoom out\n"},
+get selection(){return this.selection_},set selection(a){if(!(a instanceof f))throw"Expected TimelineSelection";var b;for(b=0;b<this.selection_.length;b++)this.selection_[b].selected=!1;this.selection_=a;cr.dispatchSimpleEvent(this,"selectionChange");for(b=0;b<this.selection_.length;b++)this.selection_[b].selected=!0;this.viewport_.dispatchChangeEvent()},setSelectionAndMakeVisible:function(a,b){if(!(a instanceof f))throw"Expected TimelineSelection";this.selection=a;var d=this.selection.range,c=this.viewport_.xWorldVectorToView(d.max-
+d.min);b&&50>c?(c=d.min+0.5*(d.max-d.min),d=5*(d.max-d.min),this.viewport_.xSetWorldRange(c-0.5*d,c+0.5*d,this.firstCanvas.width)):this.viewport_.xPanWorldRangeIntoView(d.min,d.max,this.firstCanvas.width)},get firstCanvas(){return this.tracks_.firstChild?this.tracks_.firstChild.firstCanvas:void 0},hideDragBox_:function(){this.dragBox_.style.left="-1000px";this.dragBox_.style.top="-1000px";this.dragBox_.style.width=0;this.dragBox_.style.height=0},setDragBoxPosition_:function(a,b){var d=Math.min(a.clientX,
+b.clientX),c=Math.max(a.clientX,b.clientX),f=Math.min(a.clientY,b.clientY),e=Math.max(a.clientY,b.clientY);this.dragBox_.style.left=d+"px";this.dragBox_.style.top=f+"px";this.dragBox_.style.width=c-d+"px";this.dragBox_.style.height=e-f+"px";f=this.firstCanvas;d=this.viewport_.xViewToWorld(d-f.offsetLeft);c=this.viewport_.xViewToWorld(c-f.offsetLeft);this.dragBox_.textContent=Math.round(100*(c-d))/100+"ms";f=new cr.Event("selectionChanging");f.loWX=d;f.hiWX=c;this.dispatchEvent(f)},onGridToggle_:function(a){var a=
+a?this.selection_.range.min:this.selection_.range.max,b=Math.ceil((a-this.model_.minTimestamp)/this.viewport_.gridStep_);this.viewport_.gridTimebase=a-(b+1)*this.viewport_.gridStep_;this.viewport_.gridEnabled=!0},onMouseDown_:function(a){var b=this.firstCanvas,d=this.tracks_.getClientRects()[0];d&&(a.clientX>=d.left&&a.clientX<d.right&&a.clientY>=d.top&&a.clientY<d.bottom&&a.x>=b.offsetLeft)&&(this.viewport_.xViewToWorld(a.clientX-b.offsetLeft),this.dragBeginEvent_=a,a.preventDefault(),0<=this.focusElement.tabIndex&&
+this.focusElement.focus())},onMouseMove_:function(a){if(this.firstCanvas){var b=this.firstCanvas;this.lastMouseViewPos_={x:a.clientX-b.offsetLeft,y:a.clientY-b.offsetTop};this.dragBeginEvent_&&this.setDragBoxPosition_(this.dragBeginEvent_,a)}},onMouseUp_:function(a){var b;if(this.dragBeginEvent_){this.hideDragBox_();var d=this.dragBeginEvent_;this.dragBeginEvent_=null;var c=Math.min(d.clientX,a.clientX);b=Math.max(d.clientX,a.clientX);var e=Math.min(d.clientY,a.clientY),a=Math.max(d.clientY,a.clientY),
+d=this.firstCanvas,c=this.viewport_.xViewToWorld(c-d.offsetLeft),d=this.viewport_.xViewToWorld(b-d.offsetLeft),g=new f;for(b=0;b<this.tracks_.children.length;b++){var h=this.tracks_.children[b],l=h.getBoundingClientRect(),o=Math.max(e,l.top),l=Math.min(a,l.bottom);o<=l&&h.addIntersectingItemsInRangeToSelection(c,d,e,a,g)}this.selection=g}},onDblClick_:function(a){if(!(a.x<this.firstCanvas.offsetLeft)){var b=4;a.shiftKey&&(b=1/b);this.zoomBy_(b);a.preventDefault()}}};cr.defineProperty(h,"model",cr.PropertyKind.JS);
+return{Timeline:h,TimelineSelectionSliceHit:e,TimelineSelectionCounterSampleHit:c,TimelineSelection:f,TimelineViewport:g}});cr.define("tracing",function(){function g(a){return Math.round(1E3*a)/1E3}function e(a,d){d=d||0;"string"!=typeof a&&(a=""+a);if(a.length>=d)return"";for(var c="",f=0;f<d-a.length;f++)c+=" ";return c}function c(a,d){return a+e(a,d)}function f(a,d){return e(a,d)+a}function h(a){var d="",e=a.getSliceHits(),h=a.getCounterSampleHits();if(1==e.length){var a=14,j=e[0].slice,d="Selected item:\n"+(c("Title",a)+": "+j.title+"\n"),d=d+(c("Start",a)+": "+g(j.start)+" ms\n"),d=d+(c("Duration",a)+": "+g(j.duration)+
+" ms\n");j.durationInUserTime&&(d+=c("Duration (U)",a)+": "+g(j.durationInUserTime)+" ms\n");var k=0,l;for(l in j.args)k+=1;if(0<k)for(l in d+=c("Args",a)+":\n",j.args)k=j.args[l],d+=c(" "+l,a)+": "+k+"\n"}else if(1<e.length){var a=55,d="Slices:\n",o=e.range.min,q=e.range.max;e.map(function(a){return a.slice.title});var u={};for(l=0;l<e.length;l++)j=e[l].slice,u[j.title]||(u[j.title]={slices:[]}),u[j.title].slices.push(j);j=0;for(k in u){var v=u[k],t=0;for(l=0;l<v.slices.length;l++)t+=v.slices[l].duration;
+j+=t;d+=" "+c(k,a)+": "+f(g(t)+"ms",12)+"   "+f(""+v.slices.length,5)+" occurrences\n"}d+=c("*Totals",a)+" : "+f(g(j)+"ms",12)+"   "+f(""+e.length,5)+" occurrences\n";d=d+"\n"+(c("Selection start",a)+" : "+f(g(o)+"ms",12)+"\n");d+=c("Selection extent",a)+" : "+f(g(q-o)+"ms",12)+"\n"}if(1==h.length){d="Selected counter:\n";a=55;h=h[0];e=h.counter;h=h.sampleIndex;k=[];for(l=0;l<e.numSeries;++l)k.push(e.samples[e.numSeries*h+l]);d+=c("Title",a)+": "+e.name+"\n";d+=c("Timestamp",a)+": "+g(e.timestamps[h])+
+" ms\n";d=1<e.numSeries?d+(c("Values",a)+": "+k.join("\n")+"\n"):d+(c("Value",a)+": "+k.join("\n")+"\n")}else 1<h.length&&0==e.length&&(d+="Analysis of multiple counters not yet implemented. Pick a single counter.");return d}var a=cr.ui.define("div");a.prototype={__proto__:HTMLDivElement.prototype,decorate:function(){this.className="timeline-analysis"},set selection(a){this.textContent=h(a)}};return{TimelineAnalysisView:a}});cr.define("tracing",function(){function g(a,b){var d=document.createElement("div");d.classList.add("timeline-track-button");d.classList.add("timeline-track-close-button");d.textContent=String.fromCharCode(215);d.addEventListener("click",function(){a.style.display="None"});a.appendChild(d);if(b){var c=document.createElement("div");c.classList.add("timeline-track-button");c.classList.add("timeline-track-collapse-button");c.textContent="\u2212";var f=!1;c.addEventListener("click",function(){f=!f;a.collapsedDidChange(f);
+c.textContent=f?"+":"\u2212"});a.appendChild(c)}}function e(a,b){this.string=a;this.width=b}function c(){}var f=tracing.getPallette(),h=tracing.getPalletteHighlightIdBoost(),a={},b={},d=cr.ui.define("div");d.prototype={__proto__:HTMLDivElement.prototype,decorate:function(){this.tracks_=[]},detach:function(){for(var a=0;a<this.tracks_.length;a++)this.tracks_[a].detach()},get viewport(){return this.viewport_},set viewport(a){this.viewport_=a;for(var b=0;b<this.tracks_.length;b++)this.tracks_[b].viewport=
+a;this.updateChildTracks_()},get firstCanvas(){if(this.tracks_.length)return this.tracks_[0].firstCanvas},addIntersectingItemsToSelection:function(a,b,d){for(var c=0;c<this.tracks_.length;c++){var f=this.tracks_[c].getBoundingClientRect();b>=f.top&&b<f.bottom&&this.tracks_[c].addIntersectingItemsToSelection(a,b,d)}return!1},addIntersectingItemsInRangeToSelection:function(a,b,c,d,f){for(var e=0;e<this.tracks_.length;e++){var g=this.tracks_[e].getBoundingClientRect(),h=Math.max(c,g.top),g=Math.min(d,
+g.bottom);h<=g&&this.tracks_[e].addIntersectingItemsInRangeToSelection(a,b,c,d,f)}},addAllObjectsMatchingFilterToSelection:function(a,b){for(var c=0;c<this.tracks_.length;c++)this.tracks_[c].addAllObjectsMatchingFilterToSelection(a,b)}};var m=cr.ui.define(d);m.prototype={__proto__:d.prototype,decorate:function(){this.classList.add("timeline-thread-track")},get thread(){return this.thread_},set thread(a){this.thread_=a;this.updateChildTracks_()},get tooltip(){return this.tooltip_},set tooltip(a){this.tooltip_=
+a;this.updateChildTracks_()},get heading(){return this.heading_},set heading(a){this.heading_=a;this.updateChildTracks_()},get headingWidth(){return this.headingWidth_},set headingWidth(a){this.headingWidth_=a;this.updateChildTracks_()},addTrack_:function(a){var b=new j;b.heading="";b.slices=a;b.headingWidth=this.headingWidth_;b.viewport=this.viewport_;this.tracks_.push(b);this.appendChild(b);return b},updateChildTracks_:function(){this.detach();this.textContent="";this.tracks_=[];if(this.thread_){if(this.thread_.cpuSlices){var a=
+this.addTrack_(this.thread_.cpuSlices);a.height="4px";a.decorateHit=function(a){a.thread=this.thread_}}if(this.thread_.asyncSlices.length)for(var b=this.thread_.asyncSlices.subRows,c=0;c<b.length;c++)a=this.addTrack_(b[c]),a.decorateHit=function(){},a.asyncStyle=!0;for(c=0;c<this.thread_.subRows.length;c++)a=this.addTrack_(this.thread_.subRows[c]),a.decorateHit=function(a){a.thread=this.thread_};0<this.tracks_.length&&(this.thread_.cpuSlices?(this.tracks_[1].heading=this.heading_,this.tracks_[1].tooltip=
+this.tooltip_):(this.tracks_[0].heading=this.heading_,this.tracks_[0].tooltip=this.tooltip_))}g(this,4<=this.tracks_.length)},collapsedDidChange:function(a){if(a)for(var a=parseInt(this.tracks_[0].height),b=0;b<this.tracks_.length;++b)2<a?this.tracks_[b].height=Math.floor(a)+"px":this.tracks_[b].style.display="None",a*=0.5;else for(b=0;b<this.tracks_.length;++b)this.tracks_[b].height=this.tracks_[0].height,this.tracks_[b].style.display=""}};var i=cr.ui.define(d);i.prototype={__proto__:d.prototype,
+decorate:function(){this.classList.add("timeline-thread-track")},get cpu(){return this.cpu_},set cpu(a){this.cpu_=a;this.updateChildTracks_()},get tooltip(){return this.tooltip_},set tooltip(a){this.tooltip_=a;this.updateChildTracks_()},get heading(){return this.heading_},set heading(a){this.heading_=a;this.updateChildTracks_()},get headingWidth(){return this.headingWidth_},set headingWidth(a){this.headingWidth_=a;this.updateChildTracks_()},updateChildTracks_:function(){this.detach();this.textContent=
+"";this.tracks_=[];if(this.cpu_){var a=new j;a.slices=this.cpu_.slices;a.headingWidth=this.headingWidth_;a.viewport=this.viewport_;this.tracks_.push(a);this.appendChild(a);this.tracks_[0].heading=this.heading_;this.tracks_[0].tooltip=this.tooltip_}g(this,!1)}};d=cr.ui.define("div");d.prototype={__proto__:HTMLDivElement.prototype,decorate:function(){this.className="timeline-canvas-based-track";this.slices_=null;this.headingDiv_=document.createElement("div");this.headingDiv_.className="timeline-canvas-based-track-title";
+this.headingDiv_.onselectstart=function(){return!1};this.appendChild(this.headingDiv_);this.canvasContainer_=document.createElement("div");this.canvasContainer_.className="timeline-canvas-based-track-canvas-container";this.appendChild(this.canvasContainer_);this.canvas_=document.createElement("canvas");this.canvas_.className="timeline-canvas-based-track-canvas";this.canvasContainer_.appendChild(this.canvas_);this.ctx_=this.canvas_.getContext("2d")},detach:function(){this.viewport_&&this.viewport_.removeEventListener("change",
+this.viewportChangeBoundToThis_)},set headingWidth(a){this.headingDiv_.style.width=a},get heading(){return this.headingDiv_.textContent},set heading(a){this.headingDiv_.textContent=a},set tooltip(a){this.headingDiv_.title=a},get viewport(){return this.viewport_},set viewport(a){(this.viewport_=a)&&this.viewport_.removeEventListener("change",this.viewportChangeBoundToThis_);if(this.viewport_=a)this.viewportChangeBoundToThis_=this.viewportChange_.bind(this),this.viewport_.addEventListener("change",
+this.viewportChangeBoundToThis_);this.invalidate()},viewportChange_:function(){this.invalidate()},invalidate:function(){this.rafPending_||(webkitRequestAnimationFrame(function(){this.rafPending_=!1;if(this.viewport_){var a=window.getComputedStyle(this.canvasContainer_),b=parseInt(a.width),a=parseInt(a.height);this.canvas_.width!=b&&(this.canvas_.width=b);this.canvas_.height!=a&&(this.canvas_.height=a);this.redraw()}}.bind(this),this),this.rafPending_=!0)},get firstCanvas(){return this.canvas_}};c.prototype=
+{get:function(a,c,d,f,g){var h=b[d];h||(h={},b[d]=h);f=h[c];f||(h[c]={},f=h[c]);h=f[g];if(void 0===h){for(h=!1;a.labelWidthWorld(d,c)>g;)d=d.substring(0,0.75*d.length),h=!0;h&&3<d.length&&(d=d.substring(0,d.length-3)+"...");h=new e(d,a.labelWidth(d));f[g]=h}return h}};var j=cr.ui.define(d);j.prototype={__proto__:d.prototype,SHOULD_ELIDE_TEXT:!0,decorate:function(){this.classList.add("timeline-slice-track");this.elidedTitleCache=new c;this.asyncStyle_=!1},decorateHit:function(){},get asyncStyle(){return this.asyncStyle_},
+set asyncStyle(a){this.asyncStyle_=!!a;this.invalidate()},get slices(){return this.slices_},set slices(a){this.slices_=a;this.invalidate()},get height(){return window.getComputedStyle(this).height},set height(a){this.style.height=a;this.invalidate()},labelWidth:function(b){var c=a[b];c||(c=this.ctx_.measureText(b).width,a[b]=c);return c+2},labelWidthWorld:function(a,b){return this.labelWidth(a)*b},redraw:function(){var a=this.ctx_,b=this.canvas_.width,c=this.canvas_.height;a.clearRect(0,0,b,c);var d=
+this.viewport_,e=d.xViewVectorToWorld(1),g=d.xViewToWorld(0),b=d.xViewToWorld(b);if(d.gridEnabled){var i=d.gridTimebase;for(a.beginPath();i<b;){if(i>=g){var j=d.xWorldToView(i);a.moveTo(j,0);a.lineTo(j,c)}i+=d.gridStep}a.strokeStyle="rgba(255,0,0,0.25)";a.stroke()}a.save();d.applyTransformToCanavs(a);this.asyncStyle_&&(a.globalAlpha=0.25);var k=new tracing.FastRectRenderer(a,g,2*e,2*e,b,f);k.setYandH(0,c);g=this.slices_;for(b=0;b<g.length;++b){var j=g[b],i=j.start,l=Math.max(j.duration,0.001),m=j.selected?
+j.colorId+h:j.colorId;l<e&&(l=e);0<j.duration?k.fillRect(i,l,m):0.001<e?k.fillRect(i,e,m):(a.fillStyle=f[m],a.beginPath(),a.moveTo(i-4*e,c),a.lineTo(i,0),a.lineTo(i+4*e,c),a.closePath(),a.fill())}k.flush();a.restore();if(8<c){a.textAlign="center";a.textBaseline="top";a.font="10px sans-serif";a.strokeStyle="rgb(0,0,0)";a.fillStyle="rgb(0,0,0)";c=20*e;i=this.SHOULD_ELIDE_TEXT;for(b=0;b<g.length;++b)if(j=g[b],j.duration>c&&(k=j.title,j.didNotFinish&&(k+=" (Did Not Finish)"),l=this.labelWidth(k),i&&this.labelWidthWorld(k,
+e)>j.duration&&(l=this.elidedTitleCache.get(this,e,k,l,j.duration),k=l.string,l=l.width),l*e<j.duration))j=d.xWorldToView(j.start+0.5*j.duration),a.fillText(k,j,2.5,l)}},addIntersectingItemsToSelection:function(a,b,c){var d=this.getBoundingClientRect();if(b<d.top||b>=d.bottom)return!1;a=tracing.findLowIndexInSortedIntervals(this.slices_,function(a){return a.start},function(a){return a.duration},a);return 0<=a&&a<this.slices_.length?(this.decorateHit(c.addSlice(this,this.slices_[a])),!0):!1},addIntersectingItemsInRangeToSelection:function(a,
+b,c,d,f){function e(a){a=f.addSlice(h,a);h.decorateHit(a)}var g=this.getBoundingClientRect(),c=Math.max(c,g.top),d=Math.min(d,g.bottom);if(!(c>d)){var h=this;tracing.iterateOverIntersectingIntervals(this.slices_,function(a){return a.start},function(a){return a.duration},a,b,e)}},indexOfSlice_:function(a){for(var b=tracing.findLowIndexInSortedArray(this.slices_,function(a){return a.start},a.start);b<this.slices_.length&&a.start==this.slices_[b].start&&a.colorId!=this.slices_[b].colorId;)b++;return b<
+this.slices_.length?b:void 0},addItemNearToProvidedHitToSelection:function(a,b,c){if(!a.slice)return!1;a=this.indexOfSlice_(a.slice);if(void 0===a)return!1;b=a+b;if(0>b||b>=this.slices_.length)return!1;a=c.addSlice(this,this.slices_[b]);this.decorateHit(a);return!0},addAllObjectsMatchingFilterToSelection:function(a,b){for(var c=0;c<this.slices_.length;++c)a.matchSlice(this.slices_[c])&&this.decorateHit(b.addSlice(this,this.slices_[c]))}};var k=cr.ui.define(d),l=Math.log(10);k.prototype={__proto__:d.prototype,
+decorate:function(){this.classList.add("timeline-viewport-track");this.strings_secs_=[];this.strings_msecs_=[]},redraw:function(){var a=this.ctx_,b=this.canvas_.width,c=this.canvas_.height;a.clearRect(0,0,b,c);var d=this.viewport_;d.xViewVectorToWorld(1);for(var f=d.xViewToWorld(0),e=d.xViewToWorld(b),g=d.xViewVectorToWorld(150),h=Math.pow(10,Math.ceil(Math.log(g)/l)),i=[10,5,2,1],g=0;g<i.length;++g)if(!(150>d.xWorldVectorToView(h/i[g]))){majorMarkDistanceWorld=h/i[g-1];break}h=void 0;100>majorMarkDistanceWorld?
+(unit="ms",unitDivisor=1,h=this.strings_msecs_):(unit="s",unitDivisor=1E3,h=this.strings_secs_);i=d.xWorldVectorToView(majorMarkDistanceWorld/5);g=Math.floor(f/majorMarkDistanceWorld)*majorMarkDistanceWorld;f=Math.floor(0.25*c);a.fillStyle="rgb(0, 0, 0)";a.strokeStyle="rgb(0, 0, 0)";a.textAlign="left";a.textBaseline="top";a.font="9px sans-serif";for(var j=g;j<e;j+=majorMarkDistanceWorld){var k=Math.floor(d.xWorldToView(j)),g=Math.floor(1E5*(j/unitDivisor))/1E5;h[g]||(h[g]=g+" "+unit);a.fillText(h[g],
+k+2,0);a.beginPath();a.moveTo(k,0);a.lineTo(k,b);for(g=1;5>g;++g){var m=Math.floor(k+i*g);a.moveTo(m,c-f);a.lineTo(m,c)}a.stroke()}},addIntersectingItemsToSelection:function(){},addIntersectingItemsInRangeToSelection:function(){},addAllObjectsMatchingFilterToSelection:function(){}};var o=cr.ui.define(d);o.prototype={__proto__:d.prototype,decorate:function(){this.classList.add("timeline-counter-track");g(this,!1);this.selectedSamples_={}},decorateHit:function(){},get counter(){return this.counter_},
+set counter(a){this.counter_=a;this.invalidate()},get selectedSamples(){return this.selectedSamples_},redraw:function(){var a=this.counter_,b=this.ctx_,c=this.canvas_.width,d=this.canvas_.height;b.clearRect(0,0,c,d);var e=this.viewport_,g=e.xViewVectorToWorld(1),h=e.xViewToWorld(0),c=e.xViewToWorld(c),i=e.xViewVectorToWorld(1);b.save();e.applyTransformToCanavs(b);for(var e=a.numSeries,j=a.numSamples,k=tracing.findLowIndexInSortedArray(a.timestamps,function(){},h),l=d/a.maxTotal,m=a.numSeries-1;0<=
+m;m--){b.fillStyle=f[a.seriesColors[m]];b.beginPath();for(var o=k-1,w=0<=o?a.timestamps[o]-i:-1,x=d,A=!1;;){var r=o+1;if(r>=j){b.lineTo(w,x);b.lineTo(w+8*g,x);b.lineTo(w+8*g,d);break}var s=a.timestamps[r],o=a.totals[r*e+m],z=d-l*o;if(s>c){b.lineTo(s,x);b.lineTo(s,d);break}s-w<i?o=r:(A||(b.moveTo(h,d),A=!0),b.lineTo(s,x),b.lineTo(s,z),o=r,w=s,x=z)}b.closePath();b.fill()}b.fillStyle="rgba(255, 0, 0, 1)";for(r in this.selectedSamples_)if(this.selectedSamples_[r]){s=a.timestamps[r];for(m=a.numSeries-
+1;0<=m;m--)o=a.totals[r*e+m],z=d-l*o,b.fillRect(s-g,z-1,3*g,3)}b.restore()},addIntersectingItemsToSelection:function(a,b,c){var d=this.getBoundingClientRect();if(b<d.top||b>=d.bottom)return!1;b=this.counter_;if(a<this.counter_.timestamps[0])return!1;d=tracing.findLowIndexInSortedArray(b.timestamps,function(a){return a},a);if(0>d||d>=b.timestamps.length)return!1;0<d&&a>this.counter_.timestamps[d-1]&&d--;this.getBoundingClientRect();this.decorateHit(c.addCounterSample(this,this.counter,d));return!0},
+addIntersectingItemsInRangeToSelection:function(a,b,c,d,f){var e=this.getBoundingClientRect(),c=Math.max(c,e.top),d=Math.min(d,e.bottom);if(!(c>d)){d=this.counter_;c=tracing.findLowIndexInSortedArray(d.timestamps,function(a){return a},a);e=tracing.findLowIndexInSortedArray(d.timestamps,function(a){return a},b);0<c&&a>d.timestamps[c-1]&&c--;0<e&&b>d.timestamps[e-1]&&e--;for(a=c;a<=e;a++)a>=d.timestamps.length||this.decorateHit(f.addCounterSample(this,this.counter,a))}},addAllObjectsMatchingFilterToSelection:function(){}};
+return{TimelineCounterTrack:o,TimelineSliceTrack:j,TimelineThreadTrack:m,TimelineViewportTrack:k,TimelineCpuTrack:i}});cr.define("tracing",function(){function g(e,c,f,g,a,b){this.ctx_=e;this.vpLeft_=c;this.minRectSize_=f;this.maxMergeDist_=g;this.vpRight_=a;this.pallette_=b}g.prototype={y_:0,h_:0,merging_:!1,mergeStartX_:0,mergeCurRight_:0,setYandH:function(e,c){this.flush();this.y_=e;this.h_=c},fillRect:function(e,c,f){var g=e+c;g<this.vpLeft_||e>this.vpRight_||(c<this.minRectSize_?(g-this.mergeStartX_>this.maxMergeDist_&&this.flush(),this.merging_?(this.mergeCurRight_=g,this.mergedColorId=Math.max(this.mergedColorId,
+f)):(this.merging_=!0,this.mergeStartX_=e,this.mergeCurRight_=g,this.mergedColorId=f)):(this.merging_&&this.flush(),this.ctx_.fillStyle=this.pallette_[f],this.ctx_.fillRect(e,this.y_,c,this.h_)))},flush:function(){this.merging_&&(this.ctx_.fillStyle=this.pallette_[this.mergedColorId],this.ctx_.fillRect(this.mergeStartX_,this.y_,this.mergeCurRight_-this.mergeStartX_,this.h_),this.merging_=!1)}};return{FastRectRenderer:g}});cr.define("tracing",function(){var g=cr.ui.define(cr.ui.TabPanel);g.prototype={__proto__:cr.ui.TabPanel.prototype,traceEvents_:[],systemTraceEvents_:[],decorate:function(){cr.ui.TabPanel.prototype.decorate.apply(this);this.classList.add("profiling-view");this.recordBn_=document.createElement("button");this.recordBn_.className="record";this.recordBn_.textContent="Record";this.recordBn_.addEventListener("click",this.onRecord_.bind(this));this.saveBn_=document.createElement("button");this.saveBn_.textContent=
+"Save";this.saveBn_.addEventListener("click",this.onSave_.bind(this));this.loadBn_=document.createElement("button");this.loadBn_.textContent="Load";this.loadBn_.addEventListener("click",this.onLoad_.bind(this));if(cr.isChromeOS){this.systemTracingBn_=document.createElement("input");this.systemTracingBn_.type="checkbox";this.systemTracingBn_.checked=!0;var e=document.createElement("div");e.className="label";e.textContent="System events";e.appendChild(this.systemTracingBn_)}this.timelineView_=new tracing.TimelineView;
+this.timelineView_.leftControls.appendChild(this.recordBn_);this.timelineView_.leftControls.appendChild(this.saveBn_);this.timelineView_.leftControls.appendChild(this.loadBn_);cr.isChromeOS&&this.timelineView_.leftControls.appendChild(this.systemTracingBn_);this.appendChild(this.timelineView_);document.addEventListener("keypress",this.onKeypress_.bind(this));this.refresh_()},didSetTracingController_:function(e,c){if(c)throw"Can only set tracing controller once.";this.tracingController_.addEventListener("traceEnded",
+this.onRecordDone_.bind(this));this.tracingController_.addEventListener("loadTraceFileComplete",this.onLoadTraceFileComplete_.bind(this));this.tracingController_.addEventListener("saveTraceFileComplete",this.onSaveTraceFileComplete_.bind(this));this.tracingController_.addEventListener("loadTraceFileCanceled",this.onLoadTraceFileCanceled_.bind(this));this.tracingController_.addEventListener("saveTraceFileCanceled",this.onSaveTraceFileCanceled_.bind(this));this.refresh_()},refresh_:function(){if(this.tracingController_){var e=
+this.tracingController_.traceEvents,c=e&&e.length;this.saveBn_.disabled=!c;c&&(c=new tracing.TimelineModel,c.importEvents(e,!0,[this.tracingController_.systemTraceEvents]),this.timelineView_.model=c)}},onKeypress_:function(e){if(114==e.keyCode&&!this.tracingController_.isTracingEnabled)this.onRecord_()},get timelineView(){return this.timelineView_},onRecord_:function(){this.tracingController_.beginTracing(this.systemTracingBn_?this.systemTracingBn_.checked:!1)},onRecordDone_:function(){this.refresh_()},
+onSave_:function(){this.overlayEl_=new tracing.Overlay;this.overlayEl_.className="profiling-overlay";var e=document.createElement("div");e.className="label";e.textContent="Saving...";this.overlayEl_.appendChild(e);this.overlayEl_.visible=!0;this.tracingController_.beginSaveTraceFile()},onSaveTraceFileComplete_:function(){this.overlayEl_.visible=!1;this.overlayEl_=void 0},onSaveTraceFileCanceled_:function(){this.overlayEl_.visible=!1;this.overlayEl_=void 0},onLoad_:function(){this.overlayEl_=new tracing.Overlay;
+this.overlayEl_.className="profiling-overlay";var e=document.createElement("div");e.className="label";e.textContent="Loading...";this.overlayEl_.appendChild(e);this.overlayEl_.visible=!0;this.tracingController_.beginLoadTraceFile()},onLoadTraceFileComplete_:function(){this.overlayEl_.visible=!1;this.overlayEl_=void 0;this.refresh_()},onLoadTraceFileCanceled_:function(){this.overlayEl_.visible=!1;this.overlayEl_=void 0}};cr.defineProperty(g,"tracingController",cr.PropertyKind.JS,g.prototype.didSetTracingController_);
+return{ProfilingView:g}});cr.define("tracing",function(){function g(){this.model_=this.timeline_=void 0;this.filterText_="";this.filterHits_=new tracing.TimelineSelection;this.filterHitsDirty_=!0;this.currentHitIndex_=0}var e=cr.ui.define("div");e.prototype={__proto__:tracing.Overlay.prototype,decorate:function(){tracing.Overlay.prototype.decorate.call(this);this.className="timeline-find-control";this.hitCountEl_=document.createElement("div");this.hitCountEl_.className="hit-count-label";this.hitCountEl_.textContent="1 of 7";
+var c=document.createElement("div");c.className="timeline-button find-previous";c.textContent="\u2190";c.addEventListener("click",function(){this.controller.findPrevious();this.updateHitCountEl_()}.bind(this));var e=document.createElement("div");e.className="timeline-button find-next";e.textContent="\u2192";e.addEventListener("click",function(){this.controller.findNext();this.updateHitCountEl_()}.bind(this));this.filterEl_=document.createElement("input");this.filterEl_.type="input";this.filterEl_.addEventListener("input",
+function(){this.controller.filterText=this.filterEl_.value;this.updateHitCountEl_()}.bind(this));this.filterEl_.addEventListener("keydown",function(a){13==a.keyCode?e.click():27==a.keyCode&&(this.filterEl_.blur(),this.updateHitCountEl_())}.bind(this));this.filterEl_.addEventListener("blur",function(){this.updateHitCountEl_()}.bind(this));this.filterEl_.addEventListener("focus",function(){this.updateHitCountEl_()}.bind(this));this.appendChild(this.filterEl_);this.appendChild(c);this.appendChild(e);
+this.appendChild(this.hitCountEl_);this.updateHitCountEl_()},get controller(){return this.controller_},set controller(c){this.controller_=c;this.updateHitCountEl_()},focus:function(){this.filterEl_.selectionStart=0;this.filterEl_.selectionEnd=this.filterEl_.value.length;this.filterEl_.focus()},updateHitCountEl_:function(){if(!this.controller||document.activeElement!=this.filterEl_)this.hitCountEl_.textContent="";else{var c=this.controller.currentHitIndex,e=this.controller.filterHits.length;this.hitCountEl_.textContent=
+0==e?"0 of 0":c+1+" of "+e}}};g.prototype={__proto__:Object.prototype,get timeline(){return this.timeline_},set timeline(c){this.timeline_=c;this.filterHitsDirty_=!0},get filterText(){return this.filterText_},set filterText(c){c!=this.filterText_&&(this.filterText_=c,this.filterHitsDirty_=!0,this.findNext())},get filterHits(){if(this.filterHitsDirty_)if(this.filterHitsDirty_=!1,this.timeline_){var c=new tracing.TimelineFilter(this.filterText);this.filterHits_.clear();this.timeline.addAllObjectsMatchingFilterToSelection(c,
+this.filterHits_);this.currentHitIndex_=this.filterHits_.length-1}else this.filterHits_.clear(),this.currentHitIndex_=0;return this.filterHits_},get currentHitIndex(){return this.currentHitIndex_},find_:function(c){if(this.timeline){var e=this.filterHits.length;this.currentHitIndex_+=c;0>this.currentHitIndex_&&(this.currentHitIndex_=e-1);this.currentHitIndex_>=e&&(this.currentHitIndex_=0);0>this.currentHitIndex_||this.currentHitIndex_>=e?this.timeline.selection=new tracing.TimelineSelection:(c=0==
+this.currentHitIndex_,this.timeline.setSelectionAndMakeVisible(this.filterHits.subSelection(this.currentHitIndex_),c))}},findNext:function(){this.find_(1)},findPrevious:function(){this.find_(-1)}};var c=cr.ui.define("div");c.prototype={__proto__:HTMLDivElement.prototype,decorate:function(){this.classList.add("timeline-view");this.titleEl_=document.createElement("div");this.titleEl_.textContent="Tracing: ";this.controlDiv_=document.createElement("div");this.controlDiv_.className="control";this.leftControlsEl_=
+document.createElement("div");this.leftControlsEl_.className="controls";this.rightControlsEl_=document.createElement("div");this.rightControlsEl_.className="controls";var c=document.createElement("div");c.className="spacer";this.timelineContainer_=document.createElement("div");this.timelineContainer_.className="timeline-container";var h=document.createElement("div");h.className="analysis-container";this.analysisEl_=new tracing.TimelineAnalysisView;this.findCtl_=new e;this.findCtl_.controller=new g;
+this.rightControls.appendChild(this.findCtl_);this.controlDiv_.appendChild(this.titleEl_);this.controlDiv_.appendChild(this.leftControlsEl_);this.controlDiv_.appendChild(c);this.controlDiv_.appendChild(this.rightControlsEl_);this.appendChild(this.controlDiv_);this.appendChild(this.timelineContainer_);h.appendChild(this.analysisEl_);this.appendChild(h);this.rightControls.appendChild(this.createHelpButton_());this.onSelectionChangedBoundToThis_=this.onSelectionChanged_.bind(this);document.addEventListener("keypress",
+this.onKeypress_.bind(this),!0)},createHelpButton_:function(){function c(a){if(e.visible&&(27==a.keyCode||63==a.keyCode))a.preventDefault(),document.removeEventListener("keydown",c),e.visible=!1}var e=new tracing.Overlay;e.classList.add("timeline-view-help-overlay");var a=document.createElement("div");a.className="timeline-button timeline-view-help-button";a.textContent="?";var b=document.createElement("div");b.style.whiteSpace="pre";b.style.fontFamily="monospace";a.addEventListener("click",function(){e.visible=
+!0;b.textContent=this.timeline_.keyHelp;document.addEventListener("keydown",c,!0)}.bind(this));e.appendChild(b);return a},get leftControls(){return this.leftControlsEl_},get rightControls(){return this.rightControlsEl_},get title(){return this.titleEl_.textContent.substring(this.titleEl_.textContent.length-2)},set title(c){this.titleEl_.textContent=c+":"},set traceData(c){this.model=new tracing.TimelineModel(c)},get model(){return this.timelineModel_},set model(c){this.timelineModel_=c;this.timelineContainer_.textContent=
+"";void 0!==this.timelineModel_.minTimestamp?(this.timeline_&&(this.timeline_.viewportTrack.detach(),this.timeline_.detach()),this.timeline_=new tracing.Timeline,this.timeline_.model=this.timelineModel_,this.timeline_.focusElement=this.focusElement_?this.focusElement_:this.parentElement,this.insertBefore(this.timeline_.viewportTrack,this.timelineContainer_),this.timelineContainer_.appendChild(this.timeline_),this.timeline_.addEventListener("selectionChange",this.onSelectionChangedBoundToThis_),this.findCtl_.controller.timeline=
+this.timeline_,this.onSelectionChanged_()):(this.timeline_=void 0,this.findCtl_.controller.timeline=void 0)},get timeline(){return this.timeline_},set focusElement(c){this.focusElement_=c;this.timeline_&&(this.timeline_.focusElement=c)},get focusElement(){return this.focusElement_?this.focusElement_:this.parentElement},get isAttachedToDocument_(){for(var c=this;c.parentNode;)c=c.parentNode;return c==this.ownerDocument},get listenToKeys_(){if(this.isAttachedToDocument_)return!this.focusElement_?!0:
+0<=this.focusElement.tabIndex?document.activeElement==this.focusElement:!0},onKeypress_:function(c){this.listenToKeys_&&(47==event.keyCode?(this.findCtl_.focus(),event.preventDefault()):63==c.keyCode&&(this.querySelector(".timeline-view-help-button").click(),c.preventDefault()))},beginFind:function(){if(!this.findInProgress_){this.findInProgress_=!0;var c=e();c.controller=new g;c.controller.timeline=this.timeline;c.visible=!0;c.addEventListener("close",function(){this.findInProgress_=!1}.bind(this));
+c.addEventListener("findNext",function(){});c.addEventListener("findPrevious",function(){})}},onSelectionChanged_:function(){var c=this.timelineContainer_.scrollTop;this.analysisEl_.selection=this.timeline_.selection;this.timelineContainer_.scrollTop=c}};return{TimelineFindControl:e,TimelineFindController:g,TimelineView:c}});
+</script>
+<style>
+  .view {
+    overflow: hidden;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+  }
+</style>
+</head>
+<body>
+  <div class="view">
+  </div>
+  <script>
+  'use strict';
+  var linuxPerfData = "\
+# tracer: nop\n\
+#\n\
+#           TASK-PID    CPU#    TIMESTAMP  FUNCTION\n\
+#              | |       |          |         |\n\
+    hwc_eventmon-336   [000] 50260.929925: 0: C|124|VSYNC|1\n\
+        Binder_1-340   [000] 50260.935656: 0: C|124|StatusBar|1\n\
+    hwc_eventmon-336   [000] 50260.946573: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50260.946942: 0: C|124|StatusBar|0\n\
+    hwc_eventmon-336   [000] 50260.963706: 0: C|124|VSYNC|1\n\
+     InputReader-419   [000] 50262.538578: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.538670: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.538718: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.538772: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.538780: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+     InputReader-419   [000] 50262.539646: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.539699: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.539722: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.539738: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.539745: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50262.539875: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50262.546686: 0: C|124|VSYNC|0\n\
+ InputDispatcher-418   [000] 50262.547111: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50262.558393: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.558458: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.558489: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.558523: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.558530: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50262.563342: 0: C|124|VSYNC|1\n\
+ InputDispatcher-418   [000] 50262.563756: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50262.567617: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.567676: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.567704: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.567732: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.567739: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+     InputReader-419   [000] 50262.577344: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.577409: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.577439: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.577471: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.577480: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50262.580015: 0: C|124|VSYNC|0\n\
+ InputDispatcher-418   [000] 50262.580503: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+     InputReader-419   [000] 50262.595744: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.595804: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.595831: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.595858: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.595865: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50262.596673: 0: C|124|VSYNC|1\n\
+ InputDispatcher-418   [000] 50262.597100: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+     InputReader-419   [000] 50262.605045: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.605110: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.605140: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.605173: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.605180: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50262.613350: 0: C|124|VSYNC|0\n\
+     InputReader-419   [000] 50262.614372: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.614434: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.614464: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.614484: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.614492: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+ InputDispatcher-418   [000] 50262.614657: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50262.614728: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  surfaceflinger-124   [000] 50262.617447: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50262.623957: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.624025: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.624058: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.624093: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.624100: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50262.630031: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50262.630501: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50262.632343: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.632684: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50262.633479: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.633582: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.633637: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.633673: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.633681: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_3-924   [000] 50262.641815: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50262.643090: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.643193: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.643254: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.643308: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.643317: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50262.646680: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50262.646927: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50262.648603: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_4-1276  [000] 50262.653274: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50262.654035: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.654135: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.654191: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.654253: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.654261: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50262.663039: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.663107: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.663140: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.663176: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.663184: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50262.663395: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50262.663636: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50262.665252: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50262.665463: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50262.669618: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50262.672595: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.672685: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.672740: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.672799: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.672807: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50262.680112: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50262.680511: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+     InputReader-419   [000] 50262.681754: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.681848: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.681897: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.681936: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.681943: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+ InputDispatcher-418   [000] 50262.682589: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50262.682676: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_5-9587  [000] 50262.687583: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50262.691538: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.691624: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.691676: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.691731: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.691739: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50262.696686: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50262.696940: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50262.698280: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.698450: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+        Binder_3-924   [000] 50262.702144: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50262.710606: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.710675: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.710711: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.710745: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.710752: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50262.713402: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50262.713647: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_1-340   [000] 50262.716563: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50262.730108: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50262.730476: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50262.731829: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+  surfaceflinger-124   [000] 50262.736548: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50262.746688: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50262.746941: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_1-340   [000] 50262.749600: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50262.760395: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.760467: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.760504: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.760544: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.760551: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50262.763400: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50262.763639: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_5-9587  [000] 50262.765502: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50262.770116: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.770220: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.770390: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.770437: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.770444: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50262.779628: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.779690: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.779719: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.779750: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.779758: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50262.780075: 0: C|124|VSYNC|0\n\
+ InputDispatcher-418   [000] 50262.780779: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+  SurfaceFlinger-236   [000] 50262.780922: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50262.781024: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_3-924   [000] 50262.784117: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50262.789448: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.789540: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.789596: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.789649: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.789657: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50262.796737: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50262.796984: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50262.797890: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.797975: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50262.799089: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.799153: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.799183: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.799205: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.799212: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_2-394   [000] 50262.800559: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50262.808287: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.808359: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.808393: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.808427: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.808434: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50262.813408: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50262.813652: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50262.814402: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.814618: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50262.817951: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.818021: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.818051: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.818076: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.818083: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50262.830146: 0: C|124|VSYNC|1\n\
+        Binder_3-924   [000] 50262.831773: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50262.833099: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+        Binder_2-394   [000] 50262.836346: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50262.841807: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.841894: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.841947: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.841995: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.842003: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50262.846700: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50262.846920: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50262.847846: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+        Binder_3-924   [000] 50262.850230: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50262.851741: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.851812: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.851851: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.851894: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.851903: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+     InputReader-419   [000] 50262.861316: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.861384: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.861415: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.861449: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.861456: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50262.863420: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50262.863766: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50262.864885: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_2-394   [000] 50262.867574: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50262.871934: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.872050: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.872084: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.872120: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.872128: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50262.880129: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50262.880568: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50262.881093: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.881156: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.881190: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.881214: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.881222: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+ InputDispatcher-418   [000] 50262.881997: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50262.882176: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_3-924   [000] 50262.884517: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50262.890701: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.890772: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.890806: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.890843: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.890850: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50262.896752: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50262.897080: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50262.898149: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.898400: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50262.900867: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.900941: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.900978: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.901005: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.901012: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_2-394   [000] 50262.901512: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50262.910486: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.910555: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.910586: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.910620: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.910627: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50262.913420: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50262.913737: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50262.914815: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_3-924   [000] 50262.917476: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50262.920571: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.920646: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.920688: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.920730: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.920738: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50262.930145: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50262.930552: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50262.931620: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.931707: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+        Binder_1-340   [000] 50262.934362: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50262.940247: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.940389: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.940427: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.940464: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.940471: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50262.946759: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50262.947082: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50262.948152: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+  surfaceflinger-124   [000] 50262.950834: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50262.959761: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.959832: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.959866: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.959903: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.959913: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50262.963426: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50262.963752: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_4-1276  [000] 50262.965989: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50262.969474: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.969546: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.969584: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.969625: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.969633: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50262.979043: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.979099: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.979124: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.979149: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.979157: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50262.980094: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50262.980527: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50262.981560: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50262.981739: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_5-9587  [000] 50262.984161: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50262.988800: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.988872: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.988906: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.988944: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.988953: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50262.996813: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50262.997167: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50262.999126: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+     InputReader-419   [000] 50262.999176: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50262.999231: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50262.999258: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50262.999276: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50262.999283: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50262.999633: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_4-1276  [000] 50263.002007: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.008528: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.008599: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.008634: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.008672: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.008679: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.013431: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.013760: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.014846: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_5-9587  [000] 50263.017584: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.020591: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.020671: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.020713: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.020757: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.020765: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50263.030224: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.030292: 0: C|360|iq|0\n\
+    hwc_eventmon-336   [000] 50263.030389: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.031499: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.032085: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.032111: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.032118: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+ InputDispatcher-418   [000] 50263.032668: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50263.032683: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_3-924   [000] 50263.034629: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.041891: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.041964: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.042000: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.042036: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.042043: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.046804: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.047094: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.048183: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_2-394   [000] 50263.051041: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.052037: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.052106: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.052143: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.052182: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.052189: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50263.061636: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.061703: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.061733: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.061767: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.061774: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50263.063437: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.063761: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.064854: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50263.065120: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_3-924   [000] 50263.067577: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.071452: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.071554: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.071632: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.071686: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.071693: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.080149: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.080571: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50263.080950: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.081019: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.081051: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.081077: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.081084: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+ InputDispatcher-418   [000] 50263.081945: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50263.082022: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_2-394   [000] 50263.084483: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.090710: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.090781: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.090815: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.090851: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.090858: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.096724: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.097100: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.098192: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.098457: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50263.100352: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.100420: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.100451: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.100474: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.100481: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_3-924   [000] 50263.101522: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.109994: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.110063: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.110096: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.110130: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.110138: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.113441: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.113754: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.114922: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_2-394   [000] 50263.117638: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.119682: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.119758: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.119798: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.119842: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.119849: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50263.129245: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.129301: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.129327: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.129353: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.129361: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50263.130105: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.130503: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.131494: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50263.131573: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  surfaceflinger-124   [000] 50263.134024: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.140981: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.141054: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.141089: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.141126: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.141144: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.146780: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.147127: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.148211: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.148381: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50263.150819: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.150895: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.150932: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.150958: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.150965: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_4-1276  [000] 50263.151278: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.160301: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.160399: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.160431: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.160463: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.160470: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.163488: 0: C|124|VSYNC|1\n\
+ InputDispatcher-418   [000] 50263.164288: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  SurfaceFlinger-236   [000] 50263.164505: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_5-9587  [000] 50263.167349: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.170035: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.170108: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.170150: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.170196: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.170203: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.180063: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.180468: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.181489: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.181570: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+        Binder_3-924   [000] 50263.183827: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.188824: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.188896: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.188931: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.188968: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.188975: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50263.196782: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.197093: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.198133: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+        Binder_5-9587  [000] 50263.200540: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.210451: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.210521: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.210555: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.210591: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.210598: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50263.213513: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.214309: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_1-340   [000] 50263.216575: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.220685: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.220795: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.220865: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.220928: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.220935: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.230066: 0: C|124|VSYNC|1\n\
+     InputReader-419   [000] 50263.230301: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.230390: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.230421: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.230443: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.230450: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+  SurfaceFlinger-236   [000] 50263.230653: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.231940: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50263.232019: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  surfaceflinger-124   [000] 50263.234012: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.240252: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.240381: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.240416: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.240453: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.240460: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.246786: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.247099: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.248451: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.248540: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50263.249878: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.249944: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.249973: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.249996: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.250003: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50263.252540: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.259953: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.260024: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.260059: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.260094: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.260101: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.263505: 0: C|124|VSYNC|1\n\
+ InputDispatcher-418   [000] 50263.264362: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  SurfaceFlinger-236   [000] 50263.264572: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+  surfaceflinger-124   [000] 50263.267669: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.270466: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.270544: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.270585: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.270632: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.270640: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50263.279977: 0: C|360|iq|1\n\
+    hwc_eventmon-336   [000] 50263.280074: 0: C|124|VSYNC|0\n\
+ InputDispatcher-418   [000] 50263.280286: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.280379: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.280402: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.280410: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+  SurfaceFlinger-236   [000] 50263.280599: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.281793: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50263.281866: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50263.284247: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.289772: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.289840: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.289877: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.289911: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.289919: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.296791: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.297137: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.298494: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.298703: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50263.299383: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.299444: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.299472: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.299492: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.299499: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  surfaceflinger-124   [000] 50263.301587: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50263.313507: 0: C|124|VSYNC|0\n\
+ InputDispatcher-418   [000] 50263.314358: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+  SurfaceFlinger-236   [000] 50263.314573: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_1-340   [000] 50263.317622: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.323612: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.323679: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.323714: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.323751: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.323758: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50263.330125: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.330469: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.331645: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50263.333789: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.333851: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.333882: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.333904: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.333911: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  surfaceflinger-124   [000] 50263.336467: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.343395: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.343462: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.343495: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.343529: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.343537: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.346793: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.347100: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.348331: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50263.350849: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50263.363509: 0: C|124|VSYNC|1\n\
+ InputDispatcher-418   [000] 50263.364394: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+  SurfaceFlinger-236   [000] 50263.364609: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+  surfaceflinger-124   [000] 50263.367663: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.372178: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.372248: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.372283: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.372317: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.372324: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50263.380169: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.380556: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50263.381899: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.381972: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.382007: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.382035: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.382042: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50263.382580: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50263.386421: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.391936: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.392006: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.392040: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.392077: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.392085: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.396799: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.397111: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.398190: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  surfaceflinger-124   [000] 50263.401017: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.403621: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.403697: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.403737: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.403781: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.403788: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50263.413683: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.413769: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.413808: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.413854: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.413863: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50263.413974: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.414257: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.415305: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50263.415559: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50263.417983: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.423364: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.423431: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.423464: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.423497: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.423505: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.430749: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.431043: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.432484: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.432561: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50263.433001: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.433062: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.433091: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.433109: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.433116: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  surfaceflinger-124   [000] 50263.436690: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.443086: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.443151: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.443184: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.443218: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.443225: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.446808: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.447125: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.448210: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50263.450973: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.452441: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.452517: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.452554: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.452598: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.452605: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50263.461579: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.461642: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.461670: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.461701: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.461709: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50263.463511: 0: C|124|VSYNC|1\n\
+ InputDispatcher-418   [000] 50263.464380: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+  SurfaceFlinger-236   [000] 50263.464576: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.465201: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  surfaceflinger-124   [000] 50263.467702: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.471812: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.471923: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.471991: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.472055: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.472063: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.480135: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.480549: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50263.481315: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.481379: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.481412: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.481437: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.481445: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+ InputDispatcher-418   [000] 50263.481896: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50263.481969: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50263.484055: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.490615: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.490723: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.490758: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.490795: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.490802: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.496810: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.497123: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.498140: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.498303: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50263.500527: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.500595: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.500629: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.500654: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.500661: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  surfaceflinger-124   [000] 50263.501458: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50263.513529: 0: C|124|VSYNC|0\n\
+ InputDispatcher-418   [000] 50263.514355: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+  SurfaceFlinger-236   [000] 50263.514568: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_1-340   [000] 50263.517373: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.520459: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.520539: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.520582: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.520629: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.520636: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50263.530095: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.530466: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.531481: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+        Binder_4-1276  [000] 50263.533678: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.540314: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.540444: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.540478: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.540516: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.540523: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50263.546815: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.547132: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.548370: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50263.549590: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.549654: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.549683: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.549704: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.549711: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_3-924   [000] 50263.551108: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.559205: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.559266: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.559297: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.559328: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.559336: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.563523: 0: C|124|VSYNC|1\n\
+ InputDispatcher-418   [000] 50263.564298: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  SurfaceFlinger-236   [000] 50263.564510: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_1-340   [000] 50263.567236: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.570138: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.570214: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.570258: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.570302: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.570309: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50263.579702: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.579760: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.579788: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.579816: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.579823: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50263.580147: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.580529: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.581609: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50263.581688: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_2-394   [000] 50263.583967: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.589506: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.589578: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.589613: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.589651: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.589658: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.596818: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.597143: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.598228: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.598681: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50263.599185: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.599243: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.599271: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.599289: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.599296: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50263.602629: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.608768: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.608837: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.608871: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.608903: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.608910: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.613531: 0: C|124|VSYNC|0\n\
+ InputDispatcher-418   [000] 50263.614409: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  SurfaceFlinger-236   [000] 50263.614617: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_2-394   [000] 50263.618284: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.618475: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.618552: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.618591: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.618622: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.618629: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50263.628046: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.628104: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.628130: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.628159: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.628167: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50263.630147: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.630497: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.631689: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50263.631765: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50263.634194: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.637489: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.637580: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.637623: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.637672: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.637679: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50263.646570: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.646629: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.646657: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.646689: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.646697: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50263.646823: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.647150: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.648326: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50263.648593: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_2-394   [000] 50263.651148: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50263.663535: 0: C|124|VSYNC|1\n\
+ InputDispatcher-418   [000] 50263.664402: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+  SurfaceFlinger-236   [000] 50263.664615: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_1-340   [000] 50263.668007: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50263.680109: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.681759: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50263.687131: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.687400: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.687437: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.687462: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.687469: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_3-924   [000] 50263.689480: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.696058: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.696124: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.696156: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.696186: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.696193: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.696781: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.697122: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.698349: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50263.700905: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.707004: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.707071: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.707103: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.707137: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.707144: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.713552: 0: C|124|VSYNC|0\n\
+ InputDispatcher-418   [000] 50263.714361: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  SurfaceFlinger-236   [000] 50263.714566: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.715010: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50263.717087: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.717153: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.717184: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.717206: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.717213: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_2-394   [000] 50263.718978: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.726702: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.726772: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.726805: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.726840: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.726847: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.730164: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.730520: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.731606: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50263.734241: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.736391: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.736467: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.736510: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.736555: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.736562: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50263.745981: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.746046: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.746076: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.746109: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.746116: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50263.746832: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.747148: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.748338: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50263.748607: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_2-394   [000] 50263.751147: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.755832: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.755895: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.755928: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.755962: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.755969: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.763594: 0: C|124|VSYNC|1\n\
+ InputDispatcher-418   [000] 50263.764397: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  SurfaceFlinger-236   [000] 50263.764605: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.765211: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50263.765413: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.765474: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.765505: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.765524: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.765531: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50263.767667: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.775078: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.775147: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.775181: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.775218: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.775226: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.780168: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.780537: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.781573: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.781744: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+        Binder_2-394   [000] 50263.783924: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50263.796879: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.797405: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50263.798962: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.799049: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.799174: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.799199: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.799207: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50263.799916: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.808437: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.808498: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.808527: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.808557: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.808564: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.813563: 0: C|124|VSYNC|0\n\
+ InputDispatcher-418   [000] 50263.814486: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  SurfaceFlinger-236   [000] 50263.814683: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.815104: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50263.817003: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.817072: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.817103: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.817126: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.817133: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_3-924   [000] 50263.817872: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.825449: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.825521: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.825550: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.825584: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.825591: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50263.830173: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.830518: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50263.831530: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+     InputReader-419   [000] 50263.833978: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.834052: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.834085: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.834112: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.834119: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+        Binder_2-394   [000] 50263.834446: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50263.842380: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50263.842447: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50263.842479: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.842514: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50263.842522: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+ InputDispatcher-418   [000] 50263.842909: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50263.842980: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50263.843389: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+    hwc_eventmon-336   [000] 50263.846882: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.847186: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_1-340   [000] 50263.850212: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50263.863579: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.864351: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_2-394   [000] 50263.866962: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50263.880131: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.881874: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_1-340   [000] 50263.889488: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50263.897023: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.898566: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_2-394   [000] 50263.903283: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50263.913513: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.914169: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_1-340   [000] 50263.916618: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50263.930232: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.931113: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_3-924   [000] 50263.937044: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+        Binder_1-340   [000] 50263.937399: 0: C|124|StatusBar|1\n\
+    hwc_eventmon-336   [000] 50263.947083: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.948920: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+  SurfaceFlinger-236   [000] 50263.949307: 0: C|124|StatusBar|0\n\
+        Binder_2-394   [000] 50263.956402: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50263.963582: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.963980: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_1-340   [000] 50263.972955: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50263.980270: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50263.980850: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_2-394   [000] 50263.984767: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50263.996957: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50263.997964: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_1-340   [000] 50264.001812: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50264.013623: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.014086: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_2-394   [000] 50264.019103: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50264.030314: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.032352: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_1-340   [000] 50264.037498: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50264.047063: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.048671: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_2-394   [000] 50264.055771: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50264.063590: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.064381: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_1-340   [000] 50264.067846: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50264.080281: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.081242: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+        Binder_2-394   [000] 50264.084563: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+    hwc_eventmon-336   [000] 50264.096949: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.097684: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.099533: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.099848: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.099897: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.099922: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.099930: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_5-9587  [000] 50264.102017: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+ InputDispatcher-418   [000] 50264.102901: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50264.109179: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.109241: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.109272: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.109302: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.109309: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50264.113576: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.113874: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.118895: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.118964: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.118997: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.119022: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.119029: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50264.128544: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.128613: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.128645: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.128669: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.128676: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50264.130198: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.130486: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+     InputReader-419   [000] 50264.138208: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.138277: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.138310: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.138335: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.138343: 0: C|360|wq:Window{42a6b678 com.android.launcher|4\n\
+        Binder_3-924   [000] 50264.141575: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50264.142465: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+ InputDispatcher-418   [000] 50264.142548: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50264.146935: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.147261: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+     InputReader-419   [000] 50264.148014: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.148119: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.148164: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.148193: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.148200: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+        Binder_1-340   [000] 50264.148611: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50264.149705: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50264.149781: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_3-924   [000] 50264.154311: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50264.159260: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.159332: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.159368: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.159406: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.159413: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50264.163544: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.163913: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50264.165346: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50264.167850: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50264.169005: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.169099: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.169153: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.169208: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.169215: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50264.178521: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.178584: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.178613: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.178644: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.178652: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50264.180251: 0: C|124|VSYNC|0\n\
+ InputDispatcher-418   [000] 50264.181242: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+  SurfaceFlinger-236   [000] 50264.181479: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50264.182160: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_5-9587  [000] 50264.184446: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50264.188205: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.188272: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.188308: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.188342: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.188349: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50264.196824: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.197227: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.197837: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.197930: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.197966: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.197992: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.198000: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+ InputDispatcher-418   [000] 50264.198802: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50264.198883: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  surfaceflinger-124   [000] 50264.201093: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50264.209506: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.209576: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.209611: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.209647: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.209655: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50264.213546: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.213890: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50264.215111: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_5-9587  [000] 50264.217658: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50264.219259: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.219368: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.219435: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.219508: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.219516: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50264.228801: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.228868: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.228898: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.228931: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.228939: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50264.230255: 0: C|124|VSYNC|1\n\
+ InputDispatcher-418   [000] 50264.231300: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+  SurfaceFlinger-236   [000] 50264.231504: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50264.232078: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  surfaceflinger-124   [000] 50264.234350: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50264.238622: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.238735: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.238802: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.238874: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.238881: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50264.246883: 0: C|124|VSYNC|0\n\
+ InputDispatcher-418   [000] 50264.247728: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  SurfaceFlinger-236   [000] 50264.248016: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50264.248643: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50264.249797: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.249862: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.249892: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.249914: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.249921: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_5-9587  [000] 50264.251357: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50264.259457: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.259528: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.259563: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.259600: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.259607: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50264.263546: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.263875: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50264.264946: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_4-1276  [000] 50264.267421: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50264.268862: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.268959: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.269003: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.269044: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.269052: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50264.280262: 0: C|124|VSYNC|0\n\
+ InputDispatcher-418   [000] 50264.281149: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  SurfaceFlinger-236   [000] 50264.281348: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50264.281893: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+        Binder_1-340   [000] 50264.283652: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|2\n\
+     InputReader-419   [000] 50264.294267: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.294358: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.294392: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.294426: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.294434: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50264.296885: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.297194: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.303810: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.303878: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.303911: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.303943: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.303951: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50264.312211: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.312270: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.312296: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.312324: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.312331: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50264.313506: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.313780: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50264.314575: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50264.314794: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_2-394   [000] 50264.316269: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.320843: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.320962: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.321007: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.321053: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.321060: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50264.321937: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.322448: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+    hwc_eventmon-336   [000] 50264.330226: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.330894: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+  surfaceflinger-124   [000] 50264.332504: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.346837: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.347092: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_3-924   [000] 50264.348897: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.363686: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.364654: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_1-340   [000] 50264.371874: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.381043: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.382143: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_3-924   [000] 50264.385373: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.396957: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.397664: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_5-9587  [000] 50264.400975: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.413627: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.414337: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_2-394   [000] 50264.417424: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.430443: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.431587: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_3-924   [000] 50264.437816: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.446950: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.447595: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+  surfaceflinger-124   [000] 50264.450460: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.463619: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.464269: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_2-394   [000] 50264.467106: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.480295: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.482400: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_5-9587  [000] 50264.487714: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.497064: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.497648: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_3-924   [000] 50264.504587: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.513642: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.514353: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_5-9587  [000] 50264.517482: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.530317: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.531407: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_1-340   [000] 50264.534708: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.546984: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.547489: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_4-1276  [000] 50264.554477: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.560768: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.561154: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.561289: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.561416: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.561439: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.563348: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+    hwc_eventmon-336   [000] 50264.563616: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.563850: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_3-924   [000] 50264.566084: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.567050: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.567124: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.567163: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.567268: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.567277: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+     InputReader-419   [000] 50264.576594: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.576655: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.576685: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.576714: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.576722: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50264.580245: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.580617: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50264.582197: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_4-1276  [000] 50264.584249: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.586373: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.586457: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.586504: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.586549: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.586557: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50264.595918: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.595979: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.596007: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.596036: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.596043: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50264.596909: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.597160: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50264.597951: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50264.598028: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50264.600101: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.607261: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.607336: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.607373: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.607411: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.607419: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50264.613584: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.613831: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50264.614775: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.614863: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50264.616131: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.616199: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.616230: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.616253: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.616260: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_4-1276  [000] 50264.617531: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.624606: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.624675: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.624708: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.624740: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.624748: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50264.630287: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.630563: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50264.631457: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.631577: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50264.633137: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.633210: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.633243: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.633267: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.633275: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [000] 50264.634180: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.641608: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.641675: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.641708: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.641742: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.641750: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50264.646918: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.647150: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50264.647922: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.647999: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50264.650104: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.650180: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.650216: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.650243: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.650250: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_4-1276  [000] 50264.650707: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+ InputDispatcher-418   [000] 50264.651469: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+    hwc_eventmon-336   [000] 50264.663589: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.663851: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_1-340   [000] 50264.666532: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.680257: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.682040: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_4-1276  [000] 50264.689986: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.697170: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.697910: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_1-340   [000] 50264.703464: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.713577: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.713937: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_4-1276  [000] 50264.716998: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.730386: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.730669: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_1-340   [000] 50264.733963: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.747128: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.747758: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_4-1276  [000] 50264.756273: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50264.763787: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.764359: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_1-340   [000] 50264.769884: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [001] 50264.780460: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.780997: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_4-1276  [000] 50264.785238: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [001] 50264.796942: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.797310: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_1-340   [000] 50264.803232: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [001] 50264.813649: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.814120: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_4-1276  [000] 50264.820968: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [001] 50264.830590: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.831261: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_1-340   [000] 50264.836682: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [001] 50264.847017: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.847644: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_4-1276  [000] 50264.852331: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [001] 50264.863652: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.864144: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_1-340   [000] 50264.870928: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [001] 50264.880374: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.880899: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_4-1276  [000] 50264.886351: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [001] 50264.896991: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [001] 50264.897576: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_1-340   [000] 50264.902753: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.913067: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.913312: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.913420: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.913819: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.913829: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [001] 50264.913849: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [001] 50264.914063: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50264.914835: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+        Binder_2-394   [000] 50264.916300: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.922684: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.922768: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.922813: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.922853: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.922862: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+    hwc_eventmon-336   [000] 50264.930392: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.930684: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50264.931245: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50264.932295: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.932378: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.932417: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.932448: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.932456: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_5-9587  [000] 50264.933233: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.942353: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.942418: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.942451: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.942482: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.942490: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50264.946940: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.947177: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50264.947995: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  surfaceflinger-124   [000] 50264.950072: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.952059: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.952138: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.952181: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.952227: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.952235: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50264.961670: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.961742: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.961775: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.961809: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.961817: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50264.963614: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.963857: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50264.964671: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50264.964748: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_5-9587  [000] 50264.966889: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.971512: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.971617: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.971665: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.971716: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.971723: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50264.980390: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50264.980635: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50264.981273: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.981290: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50264.981521: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.981586: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.981620: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.981643: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.981651: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  surfaceflinger-124   [000] 50264.983383: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50264.992699: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50264.992768: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50264.992803: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50264.992837: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50264.992845: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50264.996947: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50264.997171: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50264.997950: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_5-9587  [000] 50264.999950: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50265.002829: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50265.002905: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50265.002947: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50265.002988: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50265.002995: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50265.012031: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50265.012138: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50265.012169: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50265.012204: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50265.012212: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50265.013667: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.013968: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50265.014332: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50265.014350: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+  surfaceflinger-124   [000] 50265.015902: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50265.020689: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50265.020770: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50265.020818: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50265.020868: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50265.020876: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50265.028953: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50265.029010: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50265.029036: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50265.029064: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50265.029072: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50265.030366: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.030622: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50265.031383: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50265.031401: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_5-9587  [000] 50265.032680: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50265.037585: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50265.037666: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50265.037711: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50265.037754: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50265.037762: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50265.045952: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50265.046012: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50265.046041: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50265.046064: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50265.046072: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+ InputDispatcher-418   [000] 50265.046434: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [000] 50265.046450: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50265.046781: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+    hwc_eventmon-336   [000] 50265.046931: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.047167: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+  surfaceflinger-124   [000] 50265.048743: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.063594: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.063843: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_5-9587  [000] 50265.065514: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.080272: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.082058: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+  surfaceflinger-124   [000] 50265.088626: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.097206: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.097974: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_5-9587  [000] 50265.103743: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.113847: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.114585: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+  surfaceflinger-124   [000] 50265.119643: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.130393: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.130707: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_5-9587  [000] 50265.133673: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.146958: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.147311: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+  surfaceflinger-124   [000] 50265.150086: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.163837: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.164554: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_5-9587  [000] 50265.171136: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.180814: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.181741: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+  surfaceflinger-124   [000] 50265.187888: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.197170: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.197762: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_5-9587  [000] 50265.203495: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.213819: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.214394: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+  surfaceflinger-124   [000] 50265.219318: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [001] 50265.230507: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.231164: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_5-9587  [000] 50265.236364: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.247063: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.247457: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+  surfaceflinger-124   [000] 50265.251616: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.263751: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.264221: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_5-9587  [000] 50265.268582: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.280499: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.280965: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+  surfaceflinger-124   [000] 50265.287281: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.297135: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.297723: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_5-9587  [000] 50265.304429: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.313862: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.314507: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+  surfaceflinger-124   [001] 50265.321590: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50265.322668: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50265.322808: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50265.322962: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50265.323012: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50265.323020: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50265.324048: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+    hwc_eventmon-336   [000] 50265.330400: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.330649: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+     InputReader-419   [000] 50265.332052: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50265.332161: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50265.332211: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50265.332257: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50265.332265: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_1-340   [001] 50265.332384: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50265.341639: 0: C|360|iq|1\n\
+ InputDispatcher-418   [000] 50265.341708: 0: C|360|iq|0\n\
+ InputDispatcher-418   [000] 50265.341741: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50265.341770: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [000] 50265.341778: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50265.346959: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.347175: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [000] 50265.348030: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [000] 50265.348110: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+  surfaceflinger-124   [001] 50265.350202: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50265.351372: 0: C|360|iq|1\n\
+ InputDispatcher-418   [001] 50265.351484: 0: C|360|iq|0\n\
+ InputDispatcher-418   [001] 50265.351538: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [001] 50265.351596: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [001] 50265.351604: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+     InputReader-419   [000] 50265.361376: 0: C|360|iq|1\n\
+ InputDispatcher-418   [001] 50265.361431: 0: C|360|iq|0\n\
+ InputDispatcher-418   [001] 50265.361461: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [001] 50265.361490: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [001] 50265.361498: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50265.363624: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.363852: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [001] 50265.364290: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_2-394   [001] 50265.366349: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50265.371534: 0: C|360|iq|1\n\
+ InputDispatcher-418   [001] 50265.371603: 0: C|360|iq|0\n\
+ InputDispatcher-418   [001] 50265.371652: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [001] 50265.371704: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [001] 50265.371712: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50265.380316: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.380640: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [001] 50265.380987: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [001] 50265.381075: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+     InputReader-419   [000] 50265.381140: 0: C|360|iq|1\n\
+ InputDispatcher-418   [001] 50265.381191: 0: C|360|iq|0\n\
+ InputDispatcher-418   [001] 50265.381226: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [001] 50265.381246: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [001] 50265.381255: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_3-924   [001] 50265.383725: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50265.390814: 0: C|360|iq|1\n\
+ InputDispatcher-418   [001] 50265.390873: 0: C|360|iq|0\n\
+ InputDispatcher-418   [001] 50265.390911: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [001] 50265.390947: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [001] 50265.390955: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50265.396987: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.397231: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [001] 50265.397587: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [001] 50265.397676: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+        Binder_2-394   [001] 50265.399734: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50265.400521: 0: C|360|iq|1\n\
+ InputDispatcher-418   [001] 50265.400587: 0: C|360|iq|0\n\
+ InputDispatcher-418   [001] 50265.400625: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [001] 50265.400666: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [001] 50265.400674: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+     InputReader-419   [000] 50265.410148: 0: C|360|iq|1\n\
+ InputDispatcher-418   [001] 50265.410204: 0: C|360|iq|0\n\
+ InputDispatcher-418   [001] 50265.410235: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [001] 50265.410269: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [001] 50265.410277: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+    hwc_eventmon-336   [000] 50265.413660: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.413910: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [001] 50265.414273: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_3-924   [001] 50265.416395: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50265.419073: 0: C|360|iq|1\n\
+ InputDispatcher-418   [001] 50265.419139: 0: C|360|iq|0\n\
+ InputDispatcher-418   [001] 50265.419181: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [001] 50265.419227: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [001] 50265.419235: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50265.427455: 0: C|360|iq|1\n\
+ InputDispatcher-418   [001] 50265.427502: 0: C|360|iq|0\n\
+ InputDispatcher-418   [001] 50265.427530: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [001] 50265.427558: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [001] 50265.427565: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50265.430401: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.430626: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [001] 50265.430975: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [001] 50265.431068: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_2-394   [001] 50265.432887: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50265.435706: 0: C|360|iq|1\n\
+ InputDispatcher-418   [001] 50265.435776: 0: C|360|iq|0\n\
+ InputDispatcher-418   [001] 50265.435823: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [001] 50265.435870: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [001] 50265.435879: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+     InputReader-419   [000] 50265.444128: 0: C|360|iq|1\n\
+ InputDispatcher-418   [001] 50265.444180: 0: C|360|iq|0\n\
+ InputDispatcher-418   [001] 50265.444207: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [001] 50265.444237: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [001] 50265.444245: 0: C|360|wq:Window{42a6b678 com.android.launcher|3\n\
+    hwc_eventmon-336   [000] 50265.446996: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.447252: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+ InputDispatcher-418   [001] 50265.447834: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [001] 50265.447912: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+        Binder_3-924   [001] 50265.449322: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+     InputReader-419   [000] 50265.452678: 0: C|360|iq|1\n\
+ InputDispatcher-418   [001] 50265.452740: 0: C|360|iq|0\n\
+ InputDispatcher-418   [001] 50265.452785: 0: C|360|oq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [001] 50265.452832: 0: C|360|oq:Window{42a6b678 com.android.launcher|0\n\
+ InputDispatcher-418   [001] 50265.452840: 0: C|360|wq:Window{42a6b678 com.android.launcher|2\n\
+ InputDispatcher-418   [001] 50265.453537: 0: C|360|wq:Window{42a6b678 com.android.launcher|1\n\
+ InputDispatcher-418   [001] 50265.454181: 0: C|360|wq:Window{42a6b678 com.android.launcher|0\n\
+    hwc_eventmon-336   [000] 50265.463663: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.463940: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_2-394   [001] 50265.465594: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.480387: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.480614: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_3-924   [001] 50265.482914: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.496949: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.497212: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_2-394   [001] 50265.499387: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.513875: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.514574: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_3-924   [001] 50265.522162: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.530469: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.530806: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_2-394   [001] 50265.533914: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.547072: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.547390: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_3-924   [001] 50265.550459: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.563872: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.564595: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_2-394   [001] 50265.570954: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.580791: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.581489: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_3-924   [001] 50265.587293: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.597220: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.597868: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_2-394   [001] 50265.603077: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.613851: 0: C|124|VSYNC|0\n\
+  SurfaceFlinger-236   [000] 50265.614419: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_3-924   [001] 50265.618824: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [000] 50265.630510: 0: C|124|VSYNC|1\n\
+  SurfaceFlinger-236   [000] 50265.630931: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|0\n\
+        Binder_2-394   [001] 50265.635314: 0: C|124|com.android.launcher/com.android.launcher2.Launcher|1\n\
+    hwc_eventmon-336   [001] 50265.647128: 0: C|124|VSYNC|0\n";
+  </script>
+</body>
+</html>

--- a/trace_viewer/tracing/tracks/counter_track_perf_test.html
+++ b/trace_viewer/tracing/tracks/counter_track_perf_test.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2014 The Chromium Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<link rel="import" href="/tracing/importer.html">
+<link rel="import" href="/tracing/timeline_view.html">
+<link rel="import" href="/tracing/timeline_viewport.html">
+<link rel="import" href="/tracing/trace_model.html">
+
+<script>
+'use strict';
+
+tv.unittest.testSuite(function() {
+  function getSynchronous(url) {
+    var req = new XMLHttpRequest();
+    req.open('GET', url, false);
+    // Without the mime type specified like this, the file's bytes are not
+    // retrieved correctly.
+    req.overrideMimeType('text/plain; charset=x-user-defined');
+    req.send(null);
+    return req.responseText;
+  }
+
+  var ZOOM_STEPS = 10;
+  var ZOOM_COEFFICIENT = 1.2;
+
+  var model = undefined;
+
+  var drawingContainer;
+  var viewportDiv;
+
+  var viewportWidth;
+  var worldMid;
+
+  function timedCounterTrackPerfTest(name, testFn, iterations) {
+
+    function setUpOnce() {
+      if (model !== undefined)
+        return;
+      var fileUrl = '/test_data/android_systrace.html';
+      var events = getSynchronous(fileUrl);
+      model = new tracing.TraceModel();
+      model.importTraces([events], true);
+    }
+
+    function setUp() {
+      setUpOnce();
+      viewportDiv = document.createElement('div');
+
+      if (this.name === 'draw_softwareCanvas') {
+        viewportDiv.width = '200px';
+        viewportDiv.style.width = '200px';
+      }
+
+      this.addHTMLOutput(viewportDiv);
+
+      var viewport = new tracing.TimelineViewport(viewportDiv);
+
+      drawingContainer = new tracing.tracks.DrawingContainer(viewport);
+      viewport.modelTrackContainer = drawingContainer;
+
+      var modelTrack = new tracing.tracks.TraceModelTrack(viewport);
+      drawingContainer.appendChild(modelTrack);
+
+      modelTrack.model = model;
+
+      viewportDiv.appendChild(drawingContainer);
+
+      // Size the canvas.
+      drawingContainer.updateCanvasSizeIfNeeded_();
+
+      // Size the viewport.
+      viewportWidth = drawingContainer.canvas.width;
+      var min = model.bounds.min;
+      var range = model.bounds.range;
+      worldMid = min + range / 2;
+
+      var boost = range * 0.15;
+      var dt = new tracing.TimelineDisplayTransform();
+      dt.xSetWorldBounds(min - boost, min + range + boost, viewportWidth);
+      modelTrack.viewport.setDisplayTransformImmediately(dt);
+    };
+
+    function tearDown() {
+      viewportDiv.innerText = '';
+      drawingContainer = undefined;
+    }
+
+    timedPerfTest(name, testFn, {
+      setUp: setUp,
+      tearDown: tearDown,
+      iterations: iterations
+    });
+  }
+
+  var n110100 = [1, 10, 100];
+  n110100.forEach(function(val) {
+    timedCounterTrackPerfTest(
+        'draw_softwareCanvas_' + val,
+        function() {
+          for (var i = 0; i < ZOOM_STEPS; i++) {
+            var dt = drawingContainer.viewport.currentDisplayTransform.clone();
+            dt.scaleX *= ZOOM_COEFFICIENT;
+            dt.xPanWorldPosToViewPos(worldMid, 'center', viewportWidth);
+            drawingContainer.viewport.setDisplayTransformImmediately(dt);
+            drawingContainer.draw_();
+          }
+        }, val);
+  });
+});
+</script>
+


### PR DESCRIPTION
This patch adds a performance test for the <tt>CounterTrack</tt> class which was redesigned in #633. The results indicate that the redesign led to a ~12% performance regression:

![countertrack performance](https://cloud.githubusercontent.com/assets/2546601/5164672/59158a30-73d2-11e4-827a-b9857386af89.png)
