### PR TITLE
Correct the categories-expanded classlist behavior.

### DIFF
--- a/trace_viewer/about_tracing/record_selection_dialog.html
+++ b/trace_viewer/about_tracing/record_selection_dialog.html
@@ -320,6 +320,10 @@ tv.exportTo('about_tracing', function() {
             ' preset must be an array.');
       this.currentlyChosenPreset_ = preset;
 
+      if (this.currentlyChosenPreset_.length)
+        this.updateEditCategoriesStatus_(false);
+      else
+        this.updateEditCategoriesStatus_(true);
       this.updateManualCategorySelectionStatus_();
       this.updatePresetDescription_();
     },
@@ -328,7 +332,6 @@ tv.exportTo('about_tracing', function() {
       var classList = this.categoriesView_.classList;
       if (!this.usingPreset_()) {
         classList.remove('categories-column-view-hidden');
-        this.updateEditCategoriesStatus_(true);
       } else {
         if (this.editCategoriesOpened_)
           classList.remove('categories-column-view-hidden');
@@ -338,6 +341,9 @@ tv.exportTo('about_tracing', function() {
     },
 
     onClickEditCategories: function() {
+      if (!this.currentlyChosenPreset_.length)
+        return;
+
       this.updateEditCategoriesStatus_(!this.editCategoriesOpened_);
       this.updateManualCategorySelectionStatus_();
     },

--- a/trace_viewer/base/ui/dom_helpers.html
+++ b/trace_viewer/base/ui/dom_helpers.html
@@ -142,7 +142,6 @@ tv.exportTo('tv.ui', function() {
 
     var optionGroupEl = createSpan({className: 'labeled-option-group'});
     var initialValue = tv.Settings.get(settingsKey, defaultValue);
-    var didSetInitialValue = false;
     for (var i = 0; i < items.length; ++i) {
       var item = items[i];
       var id = 'category-preset-' + i;
@@ -155,11 +154,8 @@ tv.exportTo('tv.ui', function() {
       radioEl.addEventListener('change', onChange.bind(radioEl, targetEl,
                                                        targetElProperty,
                                                        settingsKey));
-      if (valuesEqual(initialValue, item.value)) {
+      if (valuesEqual(initialValue, item.value))
         radioEl.checked = true;
-        targetEl[targetElProperty] = initialValue;
-        didSetInitialValue = true;
-      }
 
       var labelEl = document.createElement('label');
       labelEl.textContent = item.label;
@@ -184,9 +180,13 @@ tv.exportTo('tv.ui', function() {
       optionGroupEl.appendChild(spanEl);
     }
     optionGroupEl.appendChild(createEditCategorySpan(optionGroupEl, targetEl));
-
-    if (!didSetInitialValue)
-      targetEl[targetElProperty] = defaultValue;
+    // Since this option group element is not yet added to the tree,
+    // querySelector will fail during updateEditCategoriesStatus_ call.
+    // Hence, creating the element with the 'expanded' classlist category
+    // added, if last selected value was 'Manual' selection.
+    if (!initialValue.length)
+      optionGroupEl.classList.add('categories-expanded');
+    targetEl[targetElProperty] = initialValue;
 
     return optionGroupEl;
   }


### PR DESCRIPTION
CL 667 modified the UX of the Record Selection dialog.
Committed CL had couple of minor issues:
1. If last selected value was 'Manual', on next invocation
   of record dialog, though the categories view was expanded
   the 'Edit categories' arrow was shown not expanded.
2. If user clicked on 'Edit categories' on a preset option,
   and then chooses another preset option, the 'Edit categories'
   was still open though it shouldn't be.

Both the issues are fixed in this CL.

BUG=603

R=dsinclair
