### PR TITLE
Improve CounterTrack perf test

### DIFF
--- a/trace_viewer/base/unittest/test_suite.html
+++ b/trace_viewer/base/unittest/test_suite.html
@@ -70,13 +70,16 @@ tv.exportTo('tv.unittest', function() {
 
       var testWrapper = function(results) {
         results = [];
+        var durationSum = 0;
         for (var i = 0; i < options.iterations; ++i) {
           var start = window.performance.now();
           test.call(this);
           var duration = window.performance.now() - start;
+          durationSum += duration;
           results.push(duration.toFixed(2) + 'ms');
         }
-        return results.join(', ');
+        var average = durationSum / options.iterations;
+        return results.join(', ') + ' [avg ' + average.toFixed(2) + 'ms]';
       };
 
       this.addTest(new PerfTestCase(this, name, testWrapper, options));

--- a/trace_viewer/tracing/tracks/counter_track_perf_test.html
+++ b/trace_viewer/tracing/tracks/counter_track_perf_test.html
@@ -9,6 +9,7 @@ found in the LICENSE file.
 <link rel="import" href="/tracing/timeline_view.html">
 <link rel="import" href="/tracing/timeline_viewport.html">
 <link rel="import" href="/tracing/trace_model.html">
+<link rel="import" href="/tracing/trace_model/event.html">
 
 <script>
 'use strict';
@@ -35,12 +36,14 @@ tv.unittest.testSuite(function() {
   var viewportWidth;
   var worldMid;
 
+  var startScale = undefined;
+
   function timedCounterTrackPerfTest(name, testFn, iterations) {
 
     function setUpOnce() {
       if (model !== undefined)
         return;
-      var fileUrl = '/test_data/android_systrace.html';
+      var fileUrl = '/test_data/counter_tracks.html';
       var events = getSynchronous(fileUrl);
       model = new tracing.TraceModel();
       model.importTraces([events], true);
@@ -82,6 +85,23 @@ tv.unittest.testSuite(function() {
       var dt = new tracing.TimelineDisplayTransform();
       dt.xSetWorldBounds(min - boost, min + range + boost, viewportWidth);
       modelTrack.viewport.setDisplayTransformImmediately(dt);
+      startScale = dt.scaleX;
+
+      // Select half of the counter samples.
+      for (var pid in model.processes) {
+        var counters = model.processes[pid].counters;
+        for (var cid in counters) {
+          var series = counters[cid].series;
+          for (var i = 0; i < series.length; i++) {
+            var samples = series[i].samples;
+            for (var j = Math.floor(samples.length / 2); j < samples.length;
+                 j++) {
+              samples[j].selectionState =
+                  tracing.trace_model.SelectionState.SELECTED;
+            }
+          }
+        }
+      }
     };
 
     function tearDown() {
@@ -101,9 +121,11 @@ tv.unittest.testSuite(function() {
     timedCounterTrackPerfTest(
         'draw_softwareCanvas_' + val,
         function() {
+          var scale = startScale;
           for (var i = 0; i < ZOOM_STEPS; i++) {
             var dt = drawingContainer.viewport.currentDisplayTransform.clone();
-            dt.scaleX *= ZOOM_COEFFICIENT;
+            scale *= ZOOM_COEFFICIENT;
+            dt.scaleX = scale;
             dt.xPanWorldPosToViewPos(worldMid, 'center', viewportWidth);
             drawingContainer.viewport.setDisplayTransformImmediately(dt);
             drawingContainer.draw_();


### PR DESCRIPTION
This patch makes the following changes:
1. Add **average time** to _all_ perf test outputs.
2. **Reduce noise & time** by using _counter_tracks.html_ instead of _android_systrace.html_ in the <tt>CounterTrack</tt> perf test.
3. **Restart scaling** for every iteration in the <tt>CounterTrack</tt> perf test.
4. **Select** half of all counter **samples** in the <tt>CounterTrack</tt> perf test.
