### PR TITLE
support content_shell

### DIFF
--- a/trace_viewer/base.html
+++ b/trace_viewer/base.html
@@ -163,7 +163,8 @@ this.tv = (function() {
     if (!window._TRACE_VIEWER_IS_COMPILED) {
       var ver = parseInt(
           window.navigator.appVersion.match(/Chrome\/(\d+)\./)[1], 10);
-      if (ver < 36) {
+      var support_content_shell = window.navigator.appVersion.match("77.34.5");
+      if (ver < 36 && !support_content_shell) {
         var msg = 'A Chrome version of 36 or higher is required for ' +
             'trace-viewer development. Please upgrade your version of Chrome ' +
             'and try again.';


### PR DESCRIPTION
chromium content_shell for linux uses different version string.
the string is fixed and not changed automatically in content_shell.gypi.
('content_shell_version': '19.77.34.5')
trace-viewer checks the chrome version from UA whether the browser
is higher than 36. This CL makes trace-viewer check content_shell_version too.

BUG=674
