### PR TITLE
Add low/high details visualisation modes for counter tracks

### DIFF
--- a/trace_viewer/tracing/timeline_track_view.html
+++ b/trace_viewer/tracing/timeline_track_view.html
@@ -405,6 +405,9 @@ tv.exportTo('tracing', function() {
         case 118:  // v
           this.toggleHighlightVSync_();
           break;
+        case 104:  // h
+          this.toggleHighDetails_();
+          break;
       }
     },
 
@@ -607,6 +610,10 @@ tv.exportTo('tracing', function() {
 
     toggleHighlightVSync_: function() {
       this.viewport_.highlightVSync = !this.viewport_.highlightVSync;
+    },
+
+    toggleHighDetails_: function() {
+      this.viewport_.highDetails = !this.viewport_.highDetails;
     },
 
     /**

--- a/trace_viewer/tracing/timeline_view.html
+++ b/trace_viewer/tracing/timeline_view.html
@@ -173,6 +173,11 @@ found in the LICENSE file.
       </div>
 
       <div class='pair'>
+        <div class='command'>h</div>
+        <div class='action'>Toggle low/high details</div>
+      </div>
+
+      <div class='pair'>
         <div class='command'>m</div>
         <div class='action'>Mark current selection</div>
       </div>

--- a/trace_viewer/tracing/timeline_viewport.html
+++ b/trace_viewer/tracing/timeline_viewport.html
@@ -47,6 +47,9 @@ tv.exportTo('tracing', function() {
     // Highlights.
     this.highlightVSync_ = false;
 
+    // High details.
+    this.highDetails_ = false;
+
     // Grid system.
     this.gridTimebase_ = 0;
     this.gridStep_ = 1000 / 60;
@@ -272,6 +275,15 @@ tv.exportTo('tracing', function() {
 
     set highlightVSync(highlightVSync) {
       this.highlightVSync_ = highlightVSync;
+      this.dispatchChangeEvent();
+    },
+
+    get highDetails() {
+      return this.highDetails_;
+    },
+
+    set highDetails(highDetails) {
+      this.highDetails_ = highDetails;
       this.dispatchChangeEvent();
     },
 

--- a/trace_viewer/tracing/tracks/counter_track.html
+++ b/trace_viewer/tracing/tracks/counter_track.html
@@ -23,6 +23,7 @@ tv.exportTo('tracing.tracks', function() {
 
   var LINE_WIDTH = 1;
   var BACKGROUND_ALPHA_MULTIPLIER = 0.5;
+  var MIN_HEIGHT = 2;
   var SQUARE_WIDTH = 3; // Unselected sample point.
   var CIRCLE_RADIUS = 2; // Selected sample point.
 
@@ -65,11 +66,14 @@ tv.exportTo('tracing.tracks', function() {
     },
 
     drawSlices_: function(viewLWorld, viewRWorld) {
+      var highDetails = this.viewport.highDetails;
+
       var ctx = this.context();
       var pixelRatio = window.devicePixelRatio || 1;
 
       var bounds = this.getBoundingClientRect();
       var height = bounds.height * pixelRatio;
+      var range = height - MIN_HEIGHT * pixelRatio;
 
       var counter = this.counter_;
 
@@ -93,7 +97,7 @@ tv.exportTo('tracing.tracks', function() {
 
       startIndex = startIndex - 1 > 0 ? startIndex - 1 : 0;
       // Draw indices one by one until we fall off the viewRWorld.
-      var yScale = height / counter.maxTotal;
+      var yScale = range / counter.maxTotal;
 
       for (var seriesIndex = counter.numSeries - 1;
            seriesIndex >= 0; seriesIndex--) {
@@ -126,7 +130,7 @@ tv.exportTo('tracing.tracks', function() {
 
             var x = timestamps[i];
             var y = counter.totals[i * numSeries + seriesIndex];
-            var yView = height - (yScale * y);
+            var yView = range - yScale * y;
 
             // If the sample is to the right of the viewport, we add a fixed
             // margin to reduce zooming clipping errors.
@@ -212,7 +216,9 @@ tv.exportTo('tracing.tracks', function() {
         }
 
         drawSeries(true);
-        drawSeries(false);
+        if (highDetails) {
+          drawSeries(false);
+        }
 
         // Calculate point density and, consequently, opacity of sample points.
         var endIndex = tv.findLowIndexInSortedArray(
@@ -239,7 +245,7 @@ tv.exportTo('tracing.tracks', function() {
         for (var i = startIndex; timestamps[i] < viewRWorld; i++) {
           var x = timestamps[i];
           var y = counter.totals[i * numSeries + seriesIndex];
-          var yView = height - (yScale * y);
+          var yView = range - yScale * y;
 
           if (series.samples[i].selected) {
             ctx.fillStyle = EventPresenter.getCounterSeriesColor(
@@ -249,7 +255,7 @@ tv.exportTo('tracing.tracks', function() {
                     2 * Math.PI);
             ctx.fill();
             ctx.stroke();
-          } else {
+          } else if (highDetails) {
             ctx.fillStyle = EventPresenter.getCounterSeriesColor(
                 series.color, series.samples[i].selectionState, opacity);
             ctx.fillRect(dt.xWorldToView(x) - (SQUARE_WIDTH / 2) * pixelRatio,


### PR DESCRIPTION
This patch adds support for switching between _low details_ and _high details_ visualisation modes of counter tracks using the "h" key (low details by default). The following two figures show the same track (with the same selection in the middle) rendered using the two modes:

_Low details:_
![countertrack_low](https://cloud.githubusercontent.com/assets/2546601/5229884/f494ff54-7715-11e4-8442-1f58021df8d1.png)

_High details:_
![countertrack_high](https://cloud.githubusercontent.com/assets/2546601/5229890/fc8248a2-7715-11e4-8e06-c525aa673122.png)

The following table shows the performance of the two modes compared to the original design (changed in #633):

![countertrack performance - google sheets](https://cloud.githubusercontent.com/assets/2546601/5229955/a635600a-7716-11e4-8917-16f43e516aeb.png)

Summary of the performance results:
- The low details mode performs slightly _better_ (1% and 4%) than the original design _without_ selection.
- The low details mode performs significantly _worse_ (92% and 35%) than the original design _with_ selection. If this is a problem, we can simplify the highlights (the low details mode currently uses the same circles as the high details mode).
- The high details mode performs significantly _worse_ (12%-129%) than the original design _both_ with and without selection (as expected). I think that this is fine.
