### PR TITLE
Improve performance of drawing counter track sample points

### DIFF
--- a/trace_viewer/tracing/tracks/counter_track.html
+++ b/trace_viewer/tracing/tracks/counter_track.html
@@ -242,22 +242,29 @@ tv.exportTo('tracing.tracks', function() {
         // Draw sample points.
         ctx.strokeStyle = EventPresenter.getCounterSeriesColor(
             series.color, SelectionState.NONE);
+        var lastFillStyle = undefined;
         for (var i = startIndex; timestamps[i] < viewRWorld; i++) {
           var x = timestamps[i];
           var y = counter.totals[i * numSeries + seriesIndex];
           var yView = range - yScale * y;
 
           if (series.samples[i].selected) {
-            ctx.fillStyle = EventPresenter.getCounterSeriesColor(
+            var fillStyle = EventPresenter.getCounterSeriesColor(
               series.color, series.samples[i].selectionState);
+            if (fillStyle !== lastFillStyle) {
+              ctx.fillStyle = lastFillStyle = fillStyle;
+            }
             ctx.beginPath();
             ctx.arc(dt.xWorldToView(x), yView, CIRCLE_RADIUS * pixelRatio, 0,
                     2 * Math.PI);
             ctx.fill();
             ctx.stroke();
           } else if (highDetails) {
-            ctx.fillStyle = EventPresenter.getCounterSeriesColor(
+            var fillStyle = EventPresenter.getCounterSeriesColor(
                 series.color, series.samples[i].selectionState, opacity);
+            if (fillStyle !== lastFillStyle) {
+              ctx.fillStyle = lastFillStyle = fillStyle;
+            }
             ctx.fillRect(dt.xWorldToView(x) - (SQUARE_WIDTH / 2) * pixelRatio,
                          yView - (SQUARE_WIDTH / 2) * pixelRatio,
                          SQUARE_WIDTH * pixelRatio, SQUARE_WIDTH * pixelRatio);


### PR DESCRIPTION
This patch improves the performance of drawing counter track sample points (rectangles and squares) in both low and high details mode. The table below shows the performance improvement:

![countertrack performance - improvement](https://cloud.githubusercontent.com/assets/2546601/5393518/b86ac79c-812a-11e4-8d92-08121448d9c5.png)

Summary of the table above:
- **Low** details **with** selection improved by **7.8%**
- **High** details **with** selection improved by **4.0%**
- **High** details **without** selection improved by **2.5%**

Note that there is still a significant gap between low details and high details performance.
