### PR TITLE
Enable scrollbars on traceviewer tests.html if required.

### DIFF
--- a/trace_viewer/base/tests.html
+++ b/trace_viewer/base/tests.html
@@ -22,7 +22,7 @@ found in the LICENSE file.
       box-sizing: border-box;
       width: 100%;
       height: 100%;
-      overflow: hidden;
+      overflow: auto;
       margin: 0px;
     }
     body > x-base-interactive-test-runner {


### PR DESCRIPTION
This is probably a regression as the page used to scroll earlier
(if I remember correctly). Not sure which change (if any) broke
this. However, currently base/tests.html is not scrollable.
