### PR TITLE
Change selected mode to 'Manual' when preset mode is modified

### DIFF
--- a/trace_viewer/about_tracing/record_selection_dialog.html
+++ b/trace_viewer/about_tracing/record_selection_dialog.html
@@ -321,14 +321,14 @@ tv.exportTo('about_tracing', function() {
       this.currentlyChosenPreset_ = preset;
 
       if (this.currentlyChosenPreset_.length)
-        this.updateEditCategoriesStatus_(false);
+        this.changeEditCategoriesState_(false);
       else
-        this.updateEditCategoriesStatus_(true);
-      this.updateManualCategorySelectionStatus_();
+        this.changeEditCategoriesState_(true);
+      this.updateManualSelectionView_();
       this.updatePresetDescription_();
     },
 
-    updateManualCategorySelectionStatus_: function() {
+    updateManualSelectionView_: function() {
       var classList = this.categoriesView_.classList;
       if (!this.usingPreset_()) {
         classList.remove('categories-column-view-hidden');
@@ -344,11 +344,11 @@ tv.exportTo('about_tracing', function() {
       if (!this.currentlyChosenPreset_.length)
         return;
 
-      this.updateEditCategoriesStatus_(!this.editCategoriesOpened_);
-      this.updateManualCategorySelectionStatus_();
+      this.changeEditCategoriesState_(!this.editCategoriesOpened_);
+      this.updateManualSelectionView_();
     },
 
-    updateEditCategoriesStatus_: function(editCategoriesState) {
+    changeEditCategoriesState_: function(editCategoriesState) {
       var presetOptionsGroup = this.querySelector('.labeled-option-group');
       if (!presetOptionsGroup)
         return;
@@ -524,6 +524,16 @@ tv.exportTo('about_tracing', function() {
     updateSetting_: function(e) {
       var checkbox = e.target;
       tv.Settings.set(checkbox.value, checkbox.checked, this.settings_key_);
+
+      // Change the current record mode to 'Manually select settings' from
+      // preset mode iff currently user is in preset record mode and user
+      // selects/deselects any category in 'Edit Categories' mode.
+      if (this.currentlyChosenPreset_.length) {
+        var categorySet = this.querySelectorAll('.labeled-option');
+        // 'Manual' option is 2nd last option in the list, hence length - 2.
+        var categoryEl = categorySet[categorySet.length - 2].children[0];
+        categoryEl.checked = true;
+      }
     },
 
     createGroupSelectButtons_: function(parent) {


### PR DESCRIPTION
User can add or delete any category record of the preset mode using
'Edit Categories'. Change the current selected recording mode to
'Manually select settings' when user modifies the default preset
recording categories set.

BUG=682
