### PR TITLE
Revert "Enable scrollbars on traceviewer tests.html if required."

### DIFF
--- a/trace_viewer/base/tests.html
+++ b/trace_viewer/base/tests.html
@@ -22,7 +22,7 @@ found in the LICENSE file.
       box-sizing: border-box;
       width: 100%;
       height: 100%;
-      overflow: auto;
+      overflow: hidden;
       margin: 0px;
     }
     body > x-base-interactive-test-runner {


### PR DESCRIPTION
Reverts google/trace-viewer#686 : per comments on the original PR, this is an incorrect change. The body is not supposed to scroll. The interactive test runner must provide scrolling.
