### PR TITLE
Hide category description when moving to manual selection mode

### DIFF
--- a/trace_viewer/extras/about_tracing/record_selection_dialog.html
+++ b/trace_viewer/extras/about_tracing/record_selection_dialog.html
@@ -555,6 +555,9 @@ tv.exportTo('tv.e.about_tracing', function() {
       if (this.currentlyChosenPreset_.length) {
         var categoryEl = document.getElementById('category-preset-Manually-select-settings');
         categoryEl.checked = true;
+        var description = this.querySelector('.category-description');
+        description.innerText = '';
+        description.classList.add('category-description-hidden');
       }
     },
 


### PR DESCRIPTION
In "Edit categories" mode, if we select/deselect any option, we
move to manual selection mode. Accordingly, we need to hide the
category description which is shown only for preset modes and
not for manual selection mode.

BUG=#701