### PR TITLE
Add a 'Highlight VSync' checkbox

### DIFF
--- a/trace_viewer/core/timeline_track_view.html
+++ b/trace_viewer/core/timeline_track_view.html
@@ -402,9 +402,6 @@ tv.exportTo('tv.c', function() {
         case 'm'.charCodeAt(0):
           this.setCurrentSelectionAsInterestRange_();
           break;
-        case 118:  // v
-          this.toggleHighlightVSync_();
-          break;
         case 104:  // h
           this.toggleHighDetails_();
           break;
@@ -606,10 +603,6 @@ tv.exportTo('tv.c', function() {
         this.viewport_.interestRange.reset();
       else
         this.viewport_.interestRange.set(selectionBounds);
-    },
-
-    toggleHighlightVSync_: function() {
-      this.viewport_.highlightVSync = !this.viewport_.highlightVSync;
     },
 
     toggleHighDetails_: function() {

--- a/trace_viewer/core/timeline_view.html
+++ b/trace_viewer/core/timeline_view.html
@@ -232,6 +232,12 @@ tv.exportTo('tv.c', function() {
           this, 'showFlowEvents',
           'tv.c.TimelineView.showFlowEvents', false,
           'Flow events'));
+      this.highlightVSync_ = false;
+      this.highlightVSyncCheckbox_ = tv.b.ui.createCheckBox(
+          this, 'highlightVSync',
+          'tv.c.TimelineView.highlightVSync', false,
+          'Highlight VSync');
+      this.rightControls.appendChild(this.highlightVSyncCheckbox_);
 
       this.rightControls.appendChild(this.createMetadataButton_());
       this.rightControls.appendChild(this.findCtl_);
@@ -267,6 +273,17 @@ tv.exportTo('tv.c', function() {
       if (!this.trackView_)
         return;
       this.trackView_.viewport.showFlowEvents = showFlowEvents;
+    },
+
+    get highlightVSync() {
+      return this.highlightVSync_;
+    },
+
+    set highlightVSync(highlightVSync) {
+      this.highlightVSync_ = highlightVSync;
+      if (!this.trackView_)
+        return;
+      this.trackView_.viewport.highlightVSync = highlightVSync;
     },
 
     createHelpButton_: function() {
@@ -404,6 +421,7 @@ tv.exportTo('tv.c', function() {
         this.trackView_.model = model;
         this.sidePanelContainer_.model = model;
         this.trackView_.viewport.showFlowEvents = this.showFlowEvents;
+        this.trackView_.viewport.highlightVSync = this.highlightVSync;
         this.clearSelectionHistory_();
       }
       tv.b.dispatchSimpleEvent(this, 'modelChange');
@@ -470,15 +488,22 @@ tv.exportTo('tv.c', function() {
       if (!this.listenToKeys_)
         return;
 
-      if (e.keyCode === '/'.charCodeAt(0)) {
-        if (this.findCtl_.hasFocus())
-          this.focus();
-        else
-          this.findCtl_.focus();
-        e.preventDefault();
-      } else if (e.keyCode === '?'.charCodeAt(0)) {
-        this.querySelector('.view-help-button').click();
-        e.preventDefault();
+      switch (e.keyCode) {
+        case 47:  // /
+          if (this.findCtl_.hasFocus())
+            this.focus();
+          else
+            this.findCtl_.focus();
+          e.preventDefault();
+          break;
+        case 63:  // ?
+          this.querySelector('.view-help-button').click();
+          e.preventDefault();
+          break;
+        case 118:  // v
+          this.toggleHighlightVSync_();
+          e.preventDefault();
+          break;
       }
     },
 
@@ -530,6 +555,11 @@ tv.exportTo('tv.c', function() {
       var vr = this.trackView_.viewport.interestRange.asRangeObject();
       if (!spc.rangeOfInterest.equals(vr))
         spc.rangeOfInterest = vr;
+    },
+
+    toggleHighlightVSync_: function() {
+      this.highlightVSyncCheckbox_.checked =
+          !this.highlightVSyncCheckbox_.checked;
     }
   };
 


### PR DESCRIPTION
This patch addresses #698 by adding a 'Highlight VSync' **checkbox** to the timeline view:

![vsync_checkbox](https://cloud.githubusercontent.com/assets/2546601/5614543/1cff6b68-94ea-11e4-892f-63a213139ba2.png)

Note that the existing keyboard shortcut <tt>v</tt> is *still working* (and in sync with the new checkbox).