### PR TITLE
Fix to be able to type 'v' into the filter text box again

### DIFF
--- a/trace_viewer/core/timeline_view.html
+++ b/trace_viewer/core/timeline_view.html
@@ -488,6 +488,7 @@ tv.exportTo('tv.c', function() {
       if (!this.listenToKeys_)
         return;
 
+      // Shortcuts that *can* steal focus from the filter text box.
       switch (e.keyCode) {
         case 47:  // /
           if (this.findCtl_.hasFocus())
@@ -500,6 +501,13 @@ tv.exportTo('tv.c', function() {
           this.querySelector('.view-help-button').click();
           e.preventDefault();
           break;
+      }
+
+      if (this.findCtl_.hasFocus())
+        return;
+
+      // Shortcuts that *can't* steal focus from the filter text box.
+      switch (e.keyCode) {
         case 118:  // v
           this.toggleHighlightVSync_();
           e.preventDefault();


### PR DESCRIPTION
This patch fixes #711, which was introduced in 3e5cdc93780fcd2733c0f6361025241885536f5d.