### PR TITLE
Register cc::DisplayItemLists for picture snapshots

### DIFF
--- a/trace_viewer/extras/cc/picture.html
+++ b/trace_viewer/extras/cc/picture.html
@@ -403,7 +403,9 @@ tv.exportTo('tv.e.cc', function() {
     }
   };
 
-  ObjectSnapshot.register(PictureSnapshot, {typeName: 'cc::Picture'});
+  ObjectSnapshot.register(
+      PictureSnapshot,
+      {typeNames: ['cc::Picture', 'cc::DisplayItemList']});
 
   return {
     PictureSnapshot: PictureSnapshot,

--- a/trace_viewer/extras/cc/picture_view.html
+++ b/trace_viewer/extras/cc/picture_view.html
@@ -43,7 +43,7 @@ tv.exportTo('tv.e.cc', function() {
   tv.c.analysis.ObjectSnapshotView.register(
       PictureSnapshotView,
       {
-        typeNames: ['cc::Picture', 'cc::LayeredPicture'],
+        typeNames: ['cc::Picture', 'cc::LayeredPicture', 'cc::DisplayItemList'],
         showInstances: false
       });
 


### PR DESCRIPTION
cc::DisplayItemLists emit trace output in the same format as
cc::Picture. This change makes PictureLayers backed by DisplayItemLists
show their contents in Frame Viewer, and allows DisplayItemsLists to be
inspected in the Skia debugger.

BUG=chromium:444181