### PR TITLE
Fix tile parsing and remove distance to visible heatmap.

### DIFF
--- a/trace_viewer/extras/cc/layer_tree_quad_stack_view.html
+++ b/trace_viewer/extras/cc/layer_tree_quad_stack_view.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <!--
-Copyright (c) 2013 The Chromium Authors. All rights reserved.
-Use of this source code is governed by a BSD-style license that can be
-found in the LICENSE file.
+ Copyright (c) 2015 The Chromium Authors. All rights reserved.
+ Use of this source code is governed by a BSD-style license that can be
+ found in the LICENSE file.
 -->
 
 <link rel="import" href="/extras/cc/picture.html">
@@ -76,7 +76,6 @@ tv.exportTo('tv.e.cc', function() {
   var TILE_HEATMAP_TYPE = {};
   TILE_HEATMAP_TYPE.NONE = 'none';
   TILE_HEATMAP_TYPE.SCHEDULED_PRIORITY = 'scheduledPriority';
-  TILE_HEATMAP_TYPE.DISTANCE_TO_VISIBLE = 'distanceToVisible';
   TILE_HEATMAP_TYPE.USING_GPU_MEMORY = 'usingGpuMemory';
 
   function createTileRectsSelectorBaseOptions() {
@@ -140,8 +139,6 @@ tv.exportTo('tv.e.cc', function() {
             value: TILE_HEATMAP_TYPE.NONE},
            {label: 'Scheduled Priority',
             value: TILE_HEATMAP_TYPE.SCHEDULED_PRIORITY},
-           {label: 'Distance to Visible',
-            value: TILE_HEATMAP_TYPE.DISTANCE_TO_VISIBLE},
            {label: 'Is using GPU memory',
             value: TILE_HEATMAP_TYPE.USING_GPU_MEMORY}
           ]);
@@ -860,8 +857,6 @@ tv.exportTo('tv.e.cc', function() {
         return tile.scheduledPriority == 0 ?
             undefined :
             tile.scheduledPriority;
-      } else if (heatmapType == TILE_HEATMAP_TYPE.DISTANCE_TO_VISIBLE) {
-        return Math.min(3000, tile.distanceToVisible);
       } else if (heatmapType == TILE_HEATMAP_TYPE.USING_GPU_MEMORY) {
         if (tile.isSolidColor)
           return 0.5;

--- a/trace_viewer/extras/cc/tile.html
+++ b/trace_viewer/extras/cc/tile.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <!--
-Copyright (c) 2013 The Chromium Authors. All rights reserved.
-Use of this source code is governed by a BSD-style license that can be
-found in the LICENSE file.
+ Copyright (c) 2015 The Chromium Authors. All rights reserved.
+ Use of this source code is governed by a BSD-style license that can be
+ found in the LICENSE file.
 -->
 
 <link rel="import" href="/extras/cc/util.html">
@@ -38,27 +38,16 @@ tv.exportTo('tv.e.cc', function() {
         this.isSolidColor = this.args.managedState.isSolidColor;
         this.isUsingGpuMemory = this.args.managedState.isUsingGpuMemory;
         this.hasResource = this.args.managedState.hasResource;
-        this.scheduledPriority = this.args.managedState.scheduledPriority;
-        if (this.args.managedState.distanceToVisible !== undefined)
-          this.distanceToVisible =
-              this.args.managedState.distanceToVisible;
-        else {
-          this.distanceToVisible =
-              this.args.managedState.distanceToVisibleInPixels;
-        }
+        this.scheduledPriority = this.args.scheduledPriority;
+        this.gpuMemoryUsageInBytes = this.args.gpuMemoryUsage;
       } else {
-        this.resolution = 'HIGH_RESOLUTION';
-        this.isSolidColor = false;
-        this.isUsingGpuMemory = false;
-        this.hasResource = false;
-        this.scheduledPriority = undefined;
-        this.distanceToVisible = undefined;
-        this.timeToVisible = undefined;
+        this.resolution = this.args.resolution;
+        this.isSolidColor = this.args.drawInfo.isSolidColor;
+        this.isUsingGpuMemory = this.args.isUsingGpuMemory;
+        this.hasResource = this.args.hasResource;
+        this.scheduledPriority = this.args.scheduledPriority;
+        this.gpuMemoryUsageInBytes = this.args.gpuMemoryUsage;
       }
-      if (this.timeToVisible > 60)
-        this.timeToVisible = 60;
-
-      this.gpuMemoryUsageInBytes = this.args.gpuMemoryUsage;
 
       // This check is for backward compatability. It can probably
       // be removed once we're confident that most traces contain


### PR DESCRIPTION
This fixes tile parsing with the tip of tree Chromium (managed tile state was merged into tile). As well, removes distanceToVisible since that information is not a part of a tile, but a part of a priority. For this to be reimplemented, we need to either be aware of the current tree in the heatmap view or to pick min/max of distances to map.