### PR TITLE
Prevent mode switching keyboard shortcuts while typing in find box

### DIFF
--- a/trace_viewer/base/ui/mouse_mode_selector.html
+++ b/trace_viewer/base/ui/mouse_mode_selector.html
@@ -149,6 +149,7 @@ tv.exportTo('tv.b.ui', function() {
           'keydown', this.onKeyDown_, this);
       tv.b.KeyEventManager.instance.addListener(
           'keyup', this.onKeyUp_, this);
+      this.keyCodeCondition = undefined;
 
       this.mode_ = undefined;
       this.modeToKeyCodeMap_ = {};
@@ -327,6 +328,10 @@ tv.exportTo('tv.b.ui', function() {
       }
     },
 
+    setKeyCodeCondition: function(callback) {
+      this.keyCodeCondition = callback;
+    },
+
     setCurrentMousePosFromEvent_: function(e) {
       this.mousePos_.x = e.clientX;
       this.mousePos_.y = e.clientY;
@@ -419,6 +424,12 @@ tv.exportTo('tv.b.ui', function() {
     onKeyUp_: function(e) {
       if (e.keyCode === ' '.charCodeAt(0))
         this.spacePressed_ = false;
+
+      if (this.keyCodeCondition != undefined && !this.keyCodeCondition()) {
+        // If keyCodeCondition is false when the FindControl is active,
+        // ignore the keyUp event.
+        return;
+      }
 
       var didHandleKey = false;
       tv.b.iterItems(this.modeToKeyCodeMap_, function(modeStr, keyCode) {

--- a/trace_viewer/core/timeline_track_view.html
+++ b/trace_viewer/core/timeline_track_view.html
@@ -202,6 +202,12 @@ tv.exportTo('tv.c', function() {
       this.mouseModeSelector_.setKeyCodeForMode(m.ZOOM, '3'.charCodeAt(0));
       this.mouseModeSelector_.setKeyCodeForMode(m.TIMING, '4'.charCodeAt(0));
 
+      this.mouseModeSelector_.setKeyCodeCondition(function() {
+        // Return false when FindControl is active so that MouseMode keyboard
+        // shortcuts are ignored.
+        return this.listenToKeys_;
+      }.bind(this));
+
       this.mouseModeSelector_.setModifierForAlternateMode(
           m.SELECTION, tv.b.ui.MODIFIER.SHIFT);
       this.mouseModeSelector_.setModifierForAlternateMode(
@@ -301,7 +307,7 @@ tv.exportTo('tv.c', function() {
 
     /**
      * Sets the element whose focus state will determine whether
-     * to respond to keybaord input.
+     * to respond to keyboard input.
      */
     set focusElement(value) {
       this.focusElement_ = value;
@@ -310,7 +316,7 @@ tv.exportTo('tv.c', function() {
     get listenToKeys_() {
       if (!this.viewport_.isAttachedToDocumentOrInTestMode)
         return false;
-      if (this.activeElement instanceof TracingFindControl)
+      if (document.activeElement instanceof TracingFindControl)
         return false;
       if (!this.focusElement_)
         return true;


### PR DESCRIPTION
This prevents switching when inputting 1, 2, 3 or 4 in the find box.
It'll be useful when functionality is added to navigate to a specific
timestamp within the find box.
