### PR TITLE
Add disabled-by-default-cc.debug.picture to FrameViewer category.

### DIFF
--- a/trace_viewer/extras/about_tracing/record_selection_dialog.html
+++ b/trace_viewer/extras/about_tracing/record_selection_dialog.html
@@ -171,7 +171,8 @@ tv.exportTo('tv.e.about_tracing', function() {
       categoryFilter: ['blink', 'cc', 'gpu', 'v8', 'toplevel']},
     {title: 'Frame Viewer',
       categoryFilter: ['blink', 'cc', 'gpu', 'v8', 'toplevel',
-        'disabled-by-default-cc.debug']},
+        'disabled-by-default-cc.debug',
+        'disabled-by-default-cc.debug.picture']},
     {title: 'Manually select settings',
       categoryFilter: []}
   ];


### PR DESCRIPTION
We've split cc.debug from cc.debug.picture since sometimes it's useful to get cc.debug information but without it being massive. However, this means that Frame Viewer category needs to have this extra category on in order to produce pictures.