### PR TITLE
Add renderer.scheduler category to some of the trace recording defaults.

### DIFF
--- a/trace_viewer/extras/about_tracing/record_selection_dialog.html
+++ b/trace_viewer/extras/about_tracing/record_selection_dialog.html
@@ -162,16 +162,18 @@ tv.exportTo('tv.e.about_tracing', function() {
 
   var DEFAULT_PRESETS = [
     {title: 'Web developer',
-      categoryFilter: ['blink', 'cc', 'net', 'toplevel', 'v8']},
+      categoryFilter: ['blink', 'cc', 'net', 'renderer.scheduler', 'toplevel',
+        'v8']},
     {title: 'Input latency',
-      categoryFilter: ['benchmark', 'input', 'toplevel']},
+      categoryFilter: ['benchmark', 'input', 'renderer.scheduler', 'toplevel']},
     {title: 'Rendering',
       categoryFilter: ['blink', 'cc', 'gpu', 'toplevel']},
     {title: 'Javascript and rendering',
-      categoryFilter: ['blink', 'cc', 'gpu', 'v8', 'toplevel']},
+      categoryFilter: ['blink', 'cc', 'gpu', 'renderer.scheduler', 'v8',
+        'toplevel']},
     {title: 'Frame Viewer',
-      categoryFilter: ['blink', 'cc', 'gpu', 'v8', 'toplevel',
-        'disabled-by-default-cc.debug']},
+      categoryFilter: ['blink', 'cc', 'gpu', 'renderer.scheduler', 'v8',
+        'toplevel', 'disabled-by-default-cc.debug']},
     {title: 'Manually select settings',
       categoryFilter: []}
   ];


### PR DESCRIPTION
This enables tracing of whether tasks occur during the idle period and
tracing of idle tasks.