### PR TITLE
Implement nav by find box functionality

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -204,6 +204,7 @@ tracing_js_html_files = [
   "trace_viewer/core/tracks/thread_track.html",
   "trace_viewer/core/tracks/trace_model_track.html",
   "trace_viewer/core/tracks/track.html",
+  "trace_viewer/core/ui_state.html",
   "trace_viewer/extras/about_tracing/about_tracing.html",
   "trace_viewer/extras/about_tracing/inspector_connection.html",
   "trace_viewer/extras/about_tracing/inspector_tracing_controller_client.html",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -135,6 +135,7 @@ tracing_js_html_files = [
   "trace_viewer/core/importer/empty_importer.html",
   "trace_viewer/core/importer/importer.html",
   "trace_viewer/core/importer/simple_line_reader.html",
+  "trace_viewer/core/location.html",
   "trace_viewer/core/selection.html",
   "trace_viewer/core/side_panel/side_panel.html",
   "trace_viewer/core/side_panel/side_panel_container.html",

--- a/trace_viewer.gyp
+++ b/trace_viewer.gyp
@@ -137,6 +137,7 @@
       'trace_viewer/core/importer/empty_importer.html',
       'trace_viewer/core/importer/importer.html',
       'trace_viewer/core/importer/simple_line_reader.html',
+      'trace_viewer/core/location.html',
       'trace_viewer/core/selection.html',
       'trace_viewer/core/side_panel/side_panel.html',
       'trace_viewer/core/side_panel/side_panel_container.html',

--- a/trace_viewer.gyp
+++ b/trace_viewer.gyp
@@ -206,6 +206,7 @@
       'trace_viewer/core/tracks/thread_track.html',
       'trace_viewer/core/tracks/trace_model_track.html',
       'trace_viewer/core/tracks/track.html',
+      'trace_viewer/core/ui_state.html',
       'trace_viewer/extras/about_tracing/about_tracing.html',
       'trace_viewer/extras/about_tracing/inspector_connection.html',
       'trace_viewer/extras/about_tracing/inspector_tracing_controller_client.html',

--- a/trace_viewer/core/find_control.html
+++ b/trace_viewer/core/find_control.html
@@ -112,7 +112,6 @@ found in the LICENSE file.
 
     filterFocus: function(e) {
       this.controller.reset();
-      this.filterTextChanged();
       this.$.filter.select();
     },
 

--- a/trace_viewer/core/find_controller.html
+++ b/trace_viewer/core/find_controller.html
@@ -7,6 +7,7 @@ found in the LICENSE file.
 
 <link rel="import" href="/base/task.html">
 <link rel="import" href="/core/filter.html">
+<link rel="import" href="/core/location.html">
 <link rel="import" href="/core/selection.html">
 
 <script>
@@ -50,6 +51,36 @@ tv.exportTo('tv.c', function() {
       this.filterHitsDirty_ = true;
     },
 
+    findSelections_: function() {
+      var promise = Promise.resolve();
+
+      var filter = new tv.c.TitleFilter(this.filterText);
+      var filterHits = new tv.c.Selection();
+      var filterTask =
+          this.timeline.addAllObjectsMatchingFilterToSelectionAsTask(
+              filter, filterHits);
+      promise = Task.RunWhenIdle(filterTask);
+      promise.then(function() {
+        this.filterHitsDirty_ = false;
+        this.filterHits_ = filterHits;
+        this.timeline.setHighlightAndClearSelection(filterHits);
+      }.bind(this));
+      return promise;
+    },
+
+    clearFindSelections_: function() {
+      this.timeline.setHighlightAndClearSelection(new tv.c.Selection());
+    },
+
+    navigateByFind_: function(timestamp, pid, tid, scaleX) {
+      if (this.timeline_ && pid >= 0 && tid >= 0 && scaleX > 0) {
+        var loc = new tv.c.Location(this.timeline.viewport);
+        loc.fromStableIdAndTimestamp(pid + '.' + tid, timestamp);
+
+        this.timeline.navToPosition(loc, scaleX);
+      }
+    },
+
     /**
      * Updates the filter hits based on the current filtering settings. Returns
      * a promise which resolves when |filterHits| has been refreshed.
@@ -63,18 +94,16 @@ tv.exportTo('tv.c', function() {
       this.filterHits_ = new tv.c.Selection();
       this.currentHitIndex_ = -1;
 
-      if (this.timeline_ && this.filterText.length) {
-        var filter = new tv.c.TitleFilter(this.filterText);
-        var filterHits = new tv.c.Selection();
-        var filterTask =
-            this.timeline.addAllObjectsMatchingFilterToSelectionAsTask(
-                filter, filterHits);
-        promise = Task.RunWhenIdle(filterTask);
-        promise.then(function() {
-          this.filterHitsDirty_ = false;
-          this.filterHits_ = filterHits;
-          this.timeline.setHighlightAndClearSelection(filterHits);
-        }.bind(this));
+      var navByFinderPattern = /^(\d+(\.\d+)?)@(\d+)\.(\d+)x(\d+(\.\d+)?)$/g;
+      var match = navByFinderPattern.exec(this.filterText);
+      if (match !== null) {
+        this.navigateByFind_(Number(match[1]), match[3],
+                             match[4], Number(match[5]));
+      } else {
+        if (this.filterText.length === 0)
+          this.clearFindSelections_();
+        else if (this.timeline_)
+          promise = this.findSelections_();
       }
       return promise;
     },

--- a/trace_viewer/core/find_controller.html
+++ b/trace_viewer/core/find_controller.html
@@ -7,8 +7,8 @@ found in the LICENSE file.
 
 <link rel="import" href="/base/task.html">
 <link rel="import" href="/core/filter.html">
-<link rel="import" href="/core/location.html">
 <link rel="import" href="/core/selection.html">
+<link rel="import" href="/core/ui_state.html">
 
 <script>
 'use strict';
@@ -51,7 +51,9 @@ tv.exportTo('tv.c', function() {
       this.filterHitsDirty_ = true;
     },
 
-    findSelections_: function() {
+    getFilterTask_: function() {
+      if (!this.timeline_)
+        return;
       var promise = Promise.resolve();
 
       var filter = new tv.c.TitleFilter(this.filterText);
@@ -72,15 +74,6 @@ tv.exportTo('tv.c', function() {
       this.timeline.setHighlightAndClearSelection(new tv.c.Selection());
     },
 
-    navigateByFind_: function(timestamp, pid, tid, scaleX) {
-      if (this.timeline_ && pid >= 0 && tid >= 0 && scaleX > 0) {
-        var loc = new tv.c.Location(this.timeline.viewport);
-        loc.fromStableIdAndTimestamp(pid + '.' + tid, timestamp);
-
-        this.timeline.navToPosition(loc, scaleX);
-      }
-    },
-
     /**
      * Updates the filter hits based on the current filtering settings. Returns
      * a promise which resolves when |filterHits| has been refreshed.
@@ -94,16 +87,24 @@ tv.exportTo('tv.c', function() {
       this.filterHits_ = new tv.c.Selection();
       this.currentHitIndex_ = -1;
 
-      var navByFinderPattern = /^(\d+(\.\d+)?)@(\d+)\.(\d+)x(\d+(\.\d+)?)$/g;
-      var match = navByFinderPattern.exec(this.filterText);
-      if (match !== null) {
-        this.navigateByFind_(Number(match[1]), match[3],
-                             match[4], Number(match[5]));
+      // Try constructing a UIState from the filterText.
+      // UIState.fromUserFriendlyString will only return a valid UIState if the
+      // string is correctly formatted and the pid,tid is found in our model.
+      var stateFromString = tv.c.UIState.fromUserFriendlyString(
+          this.timeline.viewport, this.filterText);
+      if (stateFromString instanceof Error) {
+        var overlay = new tv.b.ui.Overlay();
+        overlay.textContent = stateFromString.message;
+        overlay.title = 'UI State Navigation Error';
+        overlay.visible = true;
+      } else if (stateFromString instanceof tv.c.UIState) {
+        this.timeline.navToPosition(stateFromString);
       } else {
+        // filterText is not a navString here -- proceed with find and filter.
         if (this.filterText.length === 0)
           this.clearFindSelections_();
-        else if (this.timeline_)
-          promise = this.findSelections_();
+        else
+          promise = this.getFilterTask_();
       }
       return promise;
     },

--- a/trace_viewer/core/find_controller_test.html
+++ b/trace_viewer/core/find_controller_test.html
@@ -257,10 +257,11 @@ tv.b.unittest.testSuite(function() {
     controller.filterText = '2000@1.2x7';
 
     var cbCalls = 0;
-    timeline.navToPosition = function(location, scaleX) {
-      assertEquals(2000, location.xWorld);
-      assertEquals('1.2', location.containingTrack.eventContainer.stableId);
-      assertEquals(7, scaleX);
+    timeline.navToPosition = function(uiState) {
+      assertEquals(2000, uiState.location.xWorld);
+      assertEquals('1.2',
+          uiState.location.containingTrack.eventContainer.stableId);
+      assertEquals(7, uiState.scaleX);
       cbCalls++;
     };
     controller.updateFilterHits();

--- a/trace_viewer/core/find_controller_test.html
+++ b/trace_viewer/core/find_controller_test.html
@@ -236,5 +236,35 @@ tv.b.unittest.testSuite(function() {
     });
     return promise;
   });
+
+  test('findControllerNavigation', function() {
+    var model = new tv.c.TraceModel();
+    var p1 = model.getOrCreateProcess(1);
+    var t1 = p1.getOrCreateThread(2);
+    t1.sliceGroup.pushSlice(new tv.c.trace_model.ThreadSlice(
+        '', 'a', 0, 1, {}, 3));
+
+    var timeline = new tv.c.TimelineTrackView();
+    var vp = new tv.c.TimelineViewport(timeline);
+    timeline.model = model;
+    timeline.focusElement = timeline;
+    timeline.tabIndex = 0;
+    timeline.style.maxHeight = '600px';
+    this.addHTMLOutput(timeline);
+
+    var controller = new tv.c.FindController();
+    controller.timeline = timeline;
+    controller.filterText = '2000@1.2x7';
+
+    var cbCalls = 0;
+    timeline.navToPosition = function(location, scaleX) {
+      assertEquals(2000, location.xWorld);
+      assertEquals('1.2', location.containingTrack.eventContainer.stableId);
+      assertEquals(7, scaleX);
+      cbCalls++;
+    };
+    controller.updateFilterHits();
+    assertEquals(1, cbCalls);
+  });
 });
 </script>

--- a/trace_viewer/core/location.html
+++ b/trace_viewer/core/location.html
@@ -43,12 +43,63 @@ tv.exportTo('tv.c', function() {
    *
    * @constructor
    */
-  function Location(viewport) {
+  function Location(viewport, xWorld, yComponents) {
     this.viewport_ = viewport;
 
-    this.xWorld_ = undefined;
-    this.yComponents_ = undefined;
+    this.xWorld_ = xWorld;
+    this.yComponents_ = yComponents;
   };
+
+  Location.fromViewCoordinates = function(viewport, viewX, viewY) {
+    var dt = viewport.currentDisplayTransform;
+    var xWorld = dt.xViewToWorld(viewX);
+    var yComponents = [];
+
+    // Build yComponents by calculating percentage offset with respect to
+    // each parent track.
+    var elem = document.elementFromPoint(viewX, viewY);
+    while (elem instanceof tv.c.tracks.Track) {
+      if (elem.eventContainer) {
+        var boundRect = elem.getBoundingClientRect();
+        var yPercentOffset = (viewY - boundRect.top) / boundRect.height;
+        yComponents.push(
+            new YComponent(elem.eventContainer.stableId, yPercentOffset));
+      }
+      elem = elem.parentElement;
+    }
+
+    if (yComponents.length == 0)
+      return;
+    return new Location(viewport, xWorld, yComponents);
+  }
+
+  Location.fromStableIdAndTimestamp = function(viewport, stableId, ts) {
+    var dt = viewport.currentDisplayTransform;
+    var xWorld = ts;
+    var yComponents = [];
+
+    // The y components' percentage offsets will be calculated with respect to
+    // the boundingRect's top of containing track.
+    var containerToTrack = viewport.containerToTrackObj;
+    var elem = containerToTrack.getTrackByStableId(stableId);
+    if (!elem)
+      return;
+
+    var firstY = elem.getBoundingClientRect().top;
+    while (elem instanceof tv.c.tracks.Track) {
+      if (elem.eventContainer) {
+        var boundRect = elem.getBoundingClientRect();
+        var yPercentOffset = (firstY - boundRect.top) / boundRect.height;
+        yComponents.push(
+            new YComponent(elem.eventContainer.stableId, yPercentOffset));
+      }
+      elem = elem.parentElement;
+    }
+
+    if (yComponents.length == 0)
+      return;
+    return new Location(viewport, xWorld, yComponents);
+  }
 
   Location.prototype = {
 
@@ -61,57 +112,12 @@ tv.exportTo('tv.c', function() {
      * internal yComponents.
      */
     get containingTrack() {
-      if (this.viewport_ !== undefined) {
-        var containerToTrack = this.viewport_.containerToTrackObj;
-        for (var i in this.yComponents_) {
-          var yComponent = this.yComponents_[i];
-          var track = containerToTrack.getTrackByStableId(yComponent.stableId);
-          if (track !== undefined)
-            return track;
-        }
-      }
-    },
-
-    fromViewCoordinates: function(viewX, viewY) {
-      var dt = this.viewport_.currentDisplayTransform;
-      this.xWorld_ = Math.round(dt.xViewToWorld(viewX));
-
-      // Build yComponents by calculating percentage offset with respect to
-      // each parent track.
-      this.yComponents_ = [];
-      var elem = document.elementFromPoint(viewX, viewY);
-      while (elem instanceof tv.c.tracks.Track) {
-        if (elem.eventContainer) {
-          var boundRect = elem.getBoundingClientRect();
-          var yPercentOffset = (viewY - boundRect.top) / boundRect.height;
-          this.yComponents_.push(
-              new YComponent(elem.eventContainer.stableId, yPercentOffset));
-        }
-        elem = elem.parentElement;
-      }
-    },
-
-    fromStableIdAndTimestamp: function(stableId, ts) {
-      var dt = this.viewport_.currentDisplayTransform;
-      this.xWorld_ = ts;
-
-      // The y components' percentage offsets will be calculated with respect to
-      // the boundingRect's top of containing track.
-      this.yComponents_ = [];
       var containerToTrack = this.viewport_.containerToTrackObj;
-      var elem = containerToTrack.getTrackByStableId(stableId);
-      if (!elem)
-        return;
-
-      var firstY = elem.getBoundingClientRect().top;
-      while (elem instanceof tv.c.tracks.Track) {
-        if (elem.eventContainer) {
-          var boundRect = elem.getBoundingClientRect();
-          var yPercentOffset = (firstY - boundRect.top) / boundRect.height;
-          this.yComponents_.push(
-              new YComponent(elem.eventContainer.stableId, yPercentOffset));
-        }
-        elem = elem.parentElement;
+      for (var i in this.yComponents_) {
+        var yComponent = this.yComponents_[i];
+        var track = containerToTrack.getTrackByStableId(yComponent.stableId);
+        if (track !== undefined)
+          return track;
       }
     },
 

--- a/trace_viewer/core/location.html
+++ b/trace_viewer/core/location.html
@@ -6,7 +6,6 @@ found in the LICENSE file.
 -->
 
 <link rel="import" href="/base/base.html">
-<link rel="import" href="/core/tracks/track.html">
 
 <script>
 'use strict';
@@ -52,6 +51,27 @@ tv.exportTo('tv.c', function() {
   };
 
   Location.prototype = {
+
+    get xWorld() {
+      return this.xWorld_;
+    },
+
+    /**
+     * Returns the first valid containing track based on the
+     * internal yComponents.
+     */
+    get containingTrack() {
+      if (this.viewport_ !== undefined) {
+        var containerToTrack = this.viewport_.containerToTrackObj;
+        for (var i in this.yComponents_) {
+          var yComponent = this.yComponents_[i];
+          var track = containerToTrack.getTrackByStableId(yComponent.stableId);
+          if (track !== undefined)
+            return track;
+        }
+      }
+    },
+
     fromViewCoordinates: function(viewX, viewY) {
       var dt = this.viewport_.currentDisplayTransform;
       this.xWorld_ = Math.round(dt.xViewToWorld(viewX));
@@ -67,7 +87,30 @@ tv.exportTo('tv.c', function() {
           this.yComponents_.push(
               new YComponent(elem.eventContainer.stableId, yPercentOffset));
         }
+        elem = elem.parentElement;
+      }
+    },
 
+    fromStableIdAndTimestamp: function(stableId, ts) {
+      var dt = this.viewport_.currentDisplayTransform;
+      this.xWorld_ = ts;
+
+      // The y components' percentage offsets will be calculated with respect to
+      // the boundingRect's top of containing track.
+      this.yComponents_ = [];
+      var containerToTrack = this.viewport_.containerToTrackObj;
+      var elem = containerToTrack.getTrackByStableId(stableId);
+      if (!elem)
+        return;
+
+      var firstY = elem.getBoundingClientRect().top;
+      while (elem instanceof tv.c.tracks.Track) {
+        if (elem.eventContainer) {
+          var boundRect = elem.getBoundingClientRect();
+          var yPercentOffset = (firstY - boundRect.top) / boundRect.height;
+          this.yComponents_.push(
+              new YComponent(elem.eventContainer.stableId, yPercentOffset));
+        }
         elem = elem.parentElement;
       }
     },

--- a/trace_viewer/core/location_test.html
+++ b/trace_viewer/core/location_test.html
@@ -70,6 +70,7 @@ tv.b.unittest.testSuite(function() {
     var viewX = boundRect.left + tv.c.constants.HEADING_WIDTH;
     var viewY = boundRect.top + boundRect.height / 2;
     location.fromViewCoordinates(viewX, viewY);
+    assertEquals(asyncTrack, location.containingTrack);
     assertObjectEquals({ viewX: viewX, viewY: viewY },
                        location.toViewCoordinates());
 
@@ -81,6 +82,14 @@ tv.b.unittest.testSuite(function() {
     var expandedViewY = boundRect.top + boundRect.height;
     assertObjectEquals({ viewX: viewX, viewY: expandedViewY },
                        location.toViewCoordinates());
+
+    // Test the functionality of fromStableIdAndTimestamp.
+    var locationFromCoord = new Location(vp);
+    var locationFromStableId = new Location(vp);
+    locationFromCoord.fromViewCoordinates(viewX, boundRect.top);
+    locationFromStableId.fromStableIdAndTimestamp('123.456.AsyncSliceGroup',
+                                                  location.xWorld);
+    assertObjectEquals(locationFromCoord, locationFromStableId);
 
     // Undo scroll.
     document.getElementById('results-container').scrollTop = 0;

--- a/trace_viewer/core/location_test.html
+++ b/trace_viewer/core/location_test.html
@@ -63,13 +63,10 @@ tv.b.unittest.testSuite(function() {
     // an originally off-screen element.
     asyncTrack.scrollIntoView();
 
-    var location = new Location(vp);
-    assertObjectEquals({ viewX: null, viewY: -1 },
-                       location.toViewCoordinates());
     var boundRect = asyncTrack.getBoundingClientRect();
     var viewX = boundRect.left + tv.c.constants.HEADING_WIDTH;
     var viewY = boundRect.top + boundRect.height / 2;
-    location.fromViewCoordinates(viewX, viewY);
+    var location = Location.fromViewCoordinates(vp, viewX, viewY);
     assertEquals(asyncTrack, location.containingTrack);
     assertObjectEquals({ viewX: viewX, viewY: viewY },
                        location.toViewCoordinates());
@@ -84,11 +81,11 @@ tv.b.unittest.testSuite(function() {
                        location.toViewCoordinates());
 
     // Test the functionality of fromStableIdAndTimestamp.
-    var locationFromCoord = new Location(vp);
-    var locationFromStableId = new Location(vp);
-    locationFromCoord.fromViewCoordinates(viewX, boundRect.top);
-    locationFromStableId.fromStableIdAndTimestamp('123.456.AsyncSliceGroup',
-                                                  location.xWorld);
+    var locationFromCoord =
+        Location.fromViewCoordinates(vp, viewX, boundRect.top);
+    var locationFromStableId =
+        Location.fromStableIdAndTimestamp(vp, '123.456.AsyncSliceGroup',
+                                          location.xWorld);
     assertObjectEquals(locationFromCoord, locationFromStableId);
 
     // Undo scroll.

--- a/trace_viewer/core/timeline_track_view.html
+++ b/trace_viewer/core/timeline_track_view.html
@@ -608,10 +608,10 @@ tv.exportTo('tv.c', function() {
       this.viewport_.queueDisplayTransformAnimation(animation);
     },
 
-    navToPosition: function(location, scaleX) {
+    navToPosition: function(uiState) {
       var track = location.containingTrack;
-      if (track == undefined)
-        return;
+      var location = uiState.location;
+      var scaleX = uiState.scaleX;
 
       var worldCenter = location.xWorld;
       var viewCenter = this.modelTrackContainer_.canvas.width / 5;

--- a/trace_viewer/core/timeline_track_view.html
+++ b/trace_viewer/core/timeline_track_view.html
@@ -608,6 +608,27 @@ tv.exportTo('tv.c', function() {
       this.viewport_.queueDisplayTransformAnimation(animation);
     },
 
+    navToPosition: function(location, scaleX) {
+      var track = location.containingTrack;
+      if (track == undefined)
+        return;
+
+      var worldCenter = location.xWorld;
+      var viewCenter = this.modelTrackContainer_.canvas.width / 5;
+      var zoomInRatio = scaleX /
+          this.viewport_.currentDisplayTransform.scaleX;
+
+      // Vertically scroll so track is in view.
+      track.scrollIntoViewIfNeeded();
+
+      // Perform zoom and panX animation.
+      var animation = new tv.c.TimelineDisplayTransformZoomToAnimation(
+          worldCenter, viewCenter,
+          this.viewport_.currentDisplayTransform.panY,
+          zoomInRatio);
+      this.viewport_.queueDisplayTransformAnimation(animation);
+    },
+
     setCurrentSelectionAsInterestRange_: function() {
       var selectionBounds = this.selection.bounds;
       if (selectionBounds.empty) {

--- a/trace_viewer/core/ui_state.html
+++ b/trace_viewer/core/ui_state.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 The Chromium Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<link rel="import" href="/core/location.html">
+
+<script>
+'use strict';
+
+tv.exportTo('tv.c', function() {
+  var Location = tv.c.Location;
+
+  /**
+   * UIState is a class that represents the current state of the timeline by
+   * the Location of the point of interest and the current scaleX of the
+   * timeline.
+   *
+   * @constructor
+   */
+  function UIState(location, scaleX) {
+    this.location_ = location;
+    this.scaleX_ = scaleX;
+  };
+
+  /**
+   * Accepts a UIState string in the format of (timestamp)@(pid).(tid)x(scaleX)
+   * Returns undefined if string is not in this format, or returns an Error if
+   * accepted variables in string does not produce a valid UIState. Otherwise
+   * returns a constructed UIState instance.
+   */
+  UIState.fromUserFriendlyString = function(viewport, stateString) {
+    var navByFinderPattern = /^(\d+(\.\d+)?)@(\d+)\.(\d+)x(\d+(\.\d+)?)$/g;
+    var match = navByFinderPattern.exec(stateString);
+    if (!match)
+      return;
+
+    var timestamp = Number(match[1]);
+    var pid = match[3];
+    var tid = match[4];
+    var scaleX = Number(match[5]);
+    var loc = tv.c.Location.fromStableIdAndTimestamp(
+        viewport, pid + '.' + tid, timestamp);
+
+    if (timestamp < 0 || pid < 0 || tid < 0 || scaleX <= 0)
+      return new Error('Invalid UI State variable values.');
+
+    // Location.fromStableIdAndTimestamp will return undefined if the stableId
+    // for pid and tid is not found in our model. In that case we cannot
+    // construct a UIState for that string so we return an error.
+    if (!loc)
+      return new Error('PID/TID was not found in our model.');
+
+    return new UIState(loc, scaleX);
+  }
+
+  UIState.prototype = {
+
+    get location() {
+      return this.location_;
+    },
+
+    get scaleX() {
+      return this.scaleX_;
+    },
+
+    toJSON: function() {
+      var obj = new Object();
+      var keys = Object.keys(this);
+      for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        if (typeof this[key] === 'function')
+          continue;
+        obj[key] = this[key];
+      }
+      return obj;
+    }
+  };
+
+  return {
+    UIState: UIState
+  };
+});
+</script>

--- a/trace_viewer/core/ui_state_test.html
+++ b/trace_viewer/core/ui_state_test.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 The Chromium Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+<link rel="import" href="/core/test_utils.html">
+<link rel="import" href="/core/tracks/track.html">
+<link rel="import" href="/core/ui_state.html">
+
+<script>
+'use strict';
+
+tv.b.unittest.testSuite(function() {
+  var UIState = tv.c.UIState;
+
+  function FakeTrack() {
+  }
+
+  FakeTrack.prototype = {
+    __proto__: tv.c.tracks.Track.prototype,
+
+    get eventContainer() {
+      return { stableId: '1.2' };
+    },
+
+    getBoundingClientRect: function() {
+      return { top: 5, height: 2 };
+    }
+  };
+
+  function FakeViewPort() {
+    this.containerToTrackObj = {
+      // "1.2" is the only valid stableId this test function accepts.
+      getTrackByStableId: function(stableId) {
+        if (stableId === '1.2')
+          return new FakeTrack;
+        return undefined;
+      }
+    };
+  }
+
+  test('invalidStableId', function() {
+    var vp = new FakeViewPort;
+    assertTrue(UIState.fromUserFriendlyString(vp, '15@1.3x6') instanceof Error);
+    assertTrue(UIState.fromUserFriendlyString(vp, '15@2.2x6') instanceof Error);
+  });
+
+  test('invalidTimestamp', function() {
+    var vp = new FakeViewPort;
+    assertUndefined(UIState.fromUserFriendlyString(vp, '-1@1.2x6'));
+  });
+
+  test('invalidScaleX', function() {
+    var vp = new FakeViewPort;
+    assertUndefined(UIState.fromUserFriendlyString(vp, '1@1.2x-1'));
+    assertTrue(UIState.fromUserFriendlyString(vp, '1@1.2x0') instanceof Error);
+  });
+
+  test('invalidSyntax', function() {
+    var vp = new FakeViewPort;
+    assertUndefined(UIState.fromUserFriendlyString(vp, '5'));
+    assertUndefined(UIState.fromUserFriendlyString(vp, '505@1x5'));
+    assertUndefined(UIState.fromUserFriendlyString(vp, '505@1.x5'));
+    assertUndefined(UIState.fromUserFriendlyString(vp, '5@x5'));
+    assertUndefined(UIState.fromUserFriendlyString(vp, '1@1.2.3x5'));
+  });
+
+  test('validString', function() {
+    var vp = new FakeViewPort;
+    var uiState = UIState.fromUserFriendlyString(vp, '50125.512@1.2x1.1');
+
+    assertNotUndefined(uiState);
+    assertEquals(50125.512, uiState.location.xWorld);
+    assertEquals('1.2',
+        uiState.location.containingTrack.eventContainer.stableId);
+    assertEquals(1.1, uiState.scaleX);
+  });
+});
+</script>


### PR DESCRIPTION
This allows navigating the timeline by entering a string in
the find input box in the format of (timestamp)@(pid).(tid)x(scaleX).
A line will be drawn at that ts, the pid and tid will be brought into
view, and zoom will be applied.

The find string can also be generated by double clicking the timeline
while in mousemode=selection. A nav line will be drawn and the nav string
will be generated in the find box to be copied by the user. Single clicking
anywhere on the timeline dismisses the nav line and removes the string.

This will be useful when one would want to refer to a specific point
on the timeline in - for example - an email thread.
