### PR TITLE
Import GPU frequency changes on i915

### DIFF
--- a/trace_viewer/extras/importer/linux_perf/i915_parser.html
+++ b/trace_viewer/extras/importer/linux_perf/i915_parser.html
@@ -68,6 +68,8 @@ tv.exportTo('tv.e.importer.linux_perf', function() {
         I915Parser.prototype.flipEvent.bind(this));
     importer.registerEventHandler('i915_flip_complete',
         I915Parser.prototype.flipEvent.bind(this));
+    importer.registerEventHandler('intel_gpu_freq_change',
+        I915Parser.prototype.gpuFrequency.bind(this));
   }
 
   I915Parser.prototype = {
@@ -115,6 +117,15 @@ tv.exportTo('tv.e.importer.linux_perf', function() {
     i915RegSlice: function(ts, eventName, reg, args) {
       var kthread = this.importer.getOrCreatePseudoThread('i915_reg');
       kthread.openSlice = eventName + ':' + reg;
+      var slice = new tv.c.trace_model.Slice('', kthread.openSlice,
+          tv.b.ui.getStringColorId(kthread.openSlice), ts, args, 0);
+
+      kthread.thread.sliceGroup.pushSlice(slice);
+    },
+
+    i915FreqChangeSlice: function(ts, eventName, args) {
+      var kthread = this.importer.getOrCreatePseudoThread('i915_gpu_freq');
+      kthread.openSlice = eventName;
       var slice = new tv.c.trace_model.Slice('', kthread.openSlice,
           tv.b.ui.getStringColorId(kthread.openSlice), ts, args, 0);
 
@@ -329,6 +340,18 @@ tv.exportTo('tv.e.importer.linux_perf', function() {
               obj: obj,
               plane: plane
             });
+      return true;
+    },
+
+    gpuFrequency: function(eventName, cpuNumver, pid, ts, eventBase) {
+      var event = /new_freq=(\d+)/.exec(eventBase.details);
+      if (!event)
+        return false;
+      var freq = parseInt(event[1]);
+
+      this.i915FreqChangeSlice(ts, eventName, {
+            freq: freq
+          });
       return true;
     }
   };

--- a/trace_viewer/extras/importer/linux_perf/i915_parser_test.html
+++ b/trace_viewer/extras/importer/linux_perf/i915_parser_test.html
@@ -41,7 +41,10 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
       '          chrome-1539  [000] 18422.955660: i915_gem_ring_dispatch: ' +
                  'dev=0, ring=1, seqno=1178364',
       '          chrome-1539  [000] 18420.677772: i915_reg_rw: ' +
-                 'write reg=0x100030, len=8, val=(0xfca9001, 0xfce8007)'
+              'write reg=0x100030, len=8, val=(0xfca9001, 0xfce8007)',
+      '          kworker/u16:2-13998 [005] 1577664.436065: ' +
+              'intel_gpu_freq_change: new_freq=350'
+
     ];
     var m = new tv.c.TraceModel(lines.join('\n'), false);
     assertFalse(m.hasImportWarnings);
@@ -50,6 +53,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     var i915FlipThread = undefined;
     var i915GemRingThread = undefined;
     var i915RegThread = undefined;
+    var i915GpuFreqThread = undefined;
     m.getAllThreads().forEach(function(t) {
       switch (t.name) {
         case 'i915_gem':
@@ -64,6 +68,9 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
         case 'i915_reg':
           i915RegThread = t;
           break;
+        case 'i915_gpu_freq':
+          i915GpuFreqThread = t;
+          break;
         default:
           throw new unittest.TestError('Unexpected thread named ' + t.name);
       }
@@ -72,6 +79,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertNotUndefined(i915FlipThread);
     assertNotUndefined(i915GemRingThread);
     assertNotUndefined(i915RegThread);
+    assertNotUndefined(i915GpuFreqThread);
 
     assertEquals(3, i915GemThread.sliceGroup.length);
 
@@ -84,6 +92,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
 
     assertEquals(7, i915GemRingThread.sliceGroup.length);
     assertEquals(1, i915RegThread.sliceGroup.length);
+    assertEquals(1, i915GpuFreqThread.sliceGroup.length);
   });
 });
 </script>


### PR DESCRIPTION
With an appropriate change to the systrace helper script the Linux
kernel tracing event (intel_gpu_freq_change) is exposed which provides
the new frequency when the gpu frequency changes.

BUG=452094
TEST=New test entry added to i915Import test suite