### PR TITLE
Visually separate top level slice from slices above it

### DIFF
--- a/trace_viewer/core/draw_helpers.html
+++ b/trace_viewer/core/draw_helpers.html
@@ -182,6 +182,17 @@ tv.exportTo('tv.c', function() {
       var alpha = EventPresenter.getSliceAlpha(slice, async);
       var lightAlpha = alpha * 0.70;
 
+      // Shift the top level slice down, make it shorter, and draw a top border
+      // in order to visually separate the slice from events above it.
+      // See https://github.com/google/trace-viewer/issues/725.
+      if (slice.isTopLevel) {
+        ctx.beginPath();
+        drawLine(ctx, x, 2, w + x, 2);
+        ctx.lineWidth = 2;
+        ctx.stroke();
+        tr.setYandH(3, height - 3);
+      }
+
       // If cpuDuration is available, draw rectangles proportional to the
       // amount of cpu time taken.
       if (!slice.cpuDuration) {

--- a/trace_viewer/core/trace_model/async_slice.html
+++ b/trace_viewer/core/trace_model/async_slice.html
@@ -22,8 +22,11 @@ tv.exportTo('tv.c.trace_model', function() {
    *
    * @constructor
    */
-  function AsyncSlice(category, title, colorId, start, args) {
-    tv.c.trace_model.Slice.apply(this, arguments);
+  function AsyncSlice(category, title, colorId, start, args, duration,
+                      opt_isTopLevel) {
+    tv.c.trace_model.Slice.call(this, category, title, colorId, start, args,
+                                duration);
+    this.isTopLevel = (opt_isTopLevel === true);
   };
 
   AsyncSlice.prototype = {

--- a/trace_viewer/core/tracks/async_slice_group_track.html
+++ b/trace_viewer/core/tracks/async_slice_group_track.html
@@ -96,7 +96,6 @@ tv.exportTo('tv.c.tracks', function() {
       var subRows = [];
       for (var i = 0; i < slices.length; i++) {
         var slice = slices[i];
-        slice.isTopLevel = true;
 
         var found = false;
         var index = subRows.length;

--- a/trace_viewer/extras/importer/trace_event_importer.html
+++ b/trace_viewer/extras/importer/trace_event_importer.html
@@ -819,6 +819,7 @@ tv.exportTo('tv.e.importer', function() {
             sliceArgs = eventStateEntry.event.args;
           }
 
+          var isTopLevel = (eventStateEntry.parentEntry === undefined);
           var asyncSliceConstructor =
              tv.c.trace_model.AsyncSlice.getConstructor(
                 eventStateEntry.event.cat,
@@ -830,7 +831,8 @@ tv.exportTo('tv.e.importer', function() {
                   eventStateEntry.event.name),
               startState.event.ts / 1000,
               sliceArgs,
-              (endState.event.ts - startState.event.ts) / 1000);
+              (endState.event.ts - startState.event.ts) / 1000,
+              isTopLevel);
 
           slice.startThread = startState.thread;
           slice.endThread = endState.thread;
@@ -838,15 +840,14 @@ tv.exportTo('tv.e.importer', function() {
           if (sliceError !== undefined)
             slice.error = sliceError;
           eventStateEntry.slice = slice;
-          // Add slice to parent slice if there is a parent. Otherwise threat
-          // it as a top level slice.
-          if (eventStateEntry.parentEntry !== undefined &&
-              eventStateEntry.parentEntry.slice !== undefined) {
+          // Add the slice to the topLevelSlices array if there is no parent.
+          // Otherwise, add the slice to the subSlices of its parent.
+          if (isTopLevel) {
+            topLevelSlices.push(slice);
+          } else if (eventStateEntry.parentEntry.slice !== undefined) {
             if (eventStateEntry.parentEntry.slice.subSlices === undefined)
               eventStateEntry.parentEntry.slice.subSlices = [];
             eventStateEntry.parentEntry.slice.subSlices.push(slice);
-          } else {
-            topLevelSlices.push(slice);
           }
         }
         for (var si = 0; si < topLevelSlices.length; si++) {
@@ -940,7 +941,8 @@ tv.exportTo('tv.e.importer', function() {
                 events[0].event.ts / 1000,
                 tv.b.concatenateObjects(events[0].event.args,
                                       events[events.length - 1].event.args),
-                (event.ts - events[0].event.ts) / 1000);
+                (event.ts - events[0].event.ts) / 1000,
+                true);
             slice.startThread = events[0].thread;
             slice.endThread = asyncEventState.thread;
             slice.id = id;

--- a/trace_viewer/extras/importer/trace_event_importer_test.html
+++ b/trace_viewer/extras/importer/trace_event_importer_test.html
@@ -966,6 +966,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertEquals(1, t.asyncSliceGroup.slices.length);
     assertEquals('a', t.asyncSliceGroup.slices[0].title);
     assertEquals('cat', t.asyncSliceGroup.slices[0].category);
+    assertEquals(true, t.asyncSliceGroup.slices[0].isTopLevel);
     assertEquals(72, t.asyncSliceGroup.slices[0].id);
     assertEquals('bar', t.asyncSliceGroup.slices[0].args.foo);
     assertEquals(0, t.asyncSliceGroup.slices[0].start);
@@ -1037,6 +1038,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     var parentSlice = t.asyncSliceGroup.slices[0];
     assertEquals('c', parentSlice.title);
     assertEquals('foo', parentSlice.category);
+    assertEquals(true, parentSlice.isTopLevel);
     assertEquals(1, parentSlice.args['x']);
     assertEquals(2, parentSlice.args['y']);
 
@@ -1060,6 +1062,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     var parentSlice = t.asyncSliceGroup.slices[0];
     assertEquals('d', parentSlice.title);
     assertEquals('foo', parentSlice.category);
+    assertEquals(true, parentSlice.isTopLevel);
     assertEquals(4, parentSlice.args['z']);
 
     assertNotUndefined(parentSlice.subSlices);
@@ -1081,6 +1084,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     var parentSlice = t.asyncSliceGroup.slices[0];
     assertEquals('a', parentSlice.title);
     assertEquals('foo', parentSlice.category);
+    assertEquals(true, parentSlice.isTopLevel);
     assertEquals(0, parentSlice.start);
     assertEquals(1, parentSlice.args['x']);
     assertUndefined(parentSlice.args['y']);
@@ -1092,6 +1096,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     var subSlice = parentSlice.subSlices[0];
     assertEquals('a:s1', subSlice.title);
     assertEquals('foo', subSlice.category);
+    assertEquals(false, subSlice.isTopLevel);
     assertAlmostEquals((548 - 524) / 1000, subSlice.start);
     assertAlmostEquals((560 - 548) / 1000, subSlice.duration);
     assertUndefined(subSlice.args['x']);
@@ -1145,6 +1150,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     var parentSlice = t.asyncSliceGroup.slices[0];
     assertEquals('a', parentSlice.title);
     assertEquals('foo', parentSlice.category);
+    assertEquals(true, parentSlice.isTopLevel);
     assertEquals(0, parentSlice.start);
     assertEquals(1, parentSlice.args['x']);
     assertUndefined(parentSlice.args['y']);
@@ -1155,6 +1161,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     var subSlice = parentSlice.subSlices[0];
     assertEquals('a:s1', subSlice.title);
     assertEquals('foo', subSlice.category);
+    assertEquals(false, subSlice.isTopLevel);
     assertEquals(0, subSlice.start);
     assertAlmostEquals((548 - 524) / 1000, subSlice.duration);
     assertUndefined(subSlice.args['x']);
@@ -1200,10 +1207,12 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     var parentSlice = t.asyncSliceGroup.slices[0];
     assertEquals('a', parentSlice.title);
     assertEquals('foo', parentSlice.category);
+    assertEquals(true, parentSlice.isTopLevel);
 
     assertNotUndefined(parentSlice.subSlices);
     assertEquals(1, parentSlice.subSlices.length);
     var subSlice = parentSlice.subSlices[0];
+    assertEquals(false, subSlice.isTopLevel);
     // Arguments should include both BEGIN and END event.
     assertEquals(1, subSlice.args['x']);
     assertEquals(2, subSlice.args['y']);
@@ -1240,18 +1249,21 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertEquals('hello', paramsA.p1);
     assertEquals(123, paramsA.p2);
     assertEquals('hi', paramsA.p3);
+    assertEquals(true, sliceA.isTopLevel);
 
     var sliceB = t.asyncSliceGroup.slices[1];
     // Arguments should include both BEGIN and END event.
     var paramsB = sliceB.args['params'];
     assertNotUndefined(paramsB);
     assertEquals('foo', paramsB.p4);
+    assertEquals(true, sliceB.isTopLevel);
 
     var sliceC = t.asyncSliceGroup.slices[2];
     // Arguments should include both BEGIN and END event.
     var paramsC = sliceC.args['params'];
     assertNotUndefined(paramsC);
     assertEquals('bar', paramsC.p5);
+    assertEquals(true, sliceC.isTopLevel);
   });
 
   test('nestableAsyncManyLevels', function() {
@@ -1290,6 +1302,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertEquals('l1', l1Slice.title);
     assertAlmostEquals(0, l1Slice.start);
     assertAlmostEquals(9 / 1000, l1Slice.duration);
+    assertEquals(true, l1Slice.isTopLevel);
 
     assertNotUndefined(l1Slice.subSlices);
     assertEquals(1, l1Slice.subSlices.length);
@@ -1297,6 +1310,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertEquals('l2', l2Slice.title);
     assertAlmostEquals(1 / 1000, l2Slice.start);
     assertAlmostEquals(7 / 1000, l2Slice.duration);
+    assertEquals(false, l2Slice.isTopLevel);
 
     assertNotUndefined(l2Slice.subSlices);
     assertEquals(1, l2Slice.subSlices.length);
@@ -1304,6 +1318,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertEquals('l3', l3Slice.title);
     assertAlmostEquals(2 / 1000, l3Slice.start);
     assertAlmostEquals(5 / 1000, l3Slice.duration);
+    assertEquals(false, l3Slice.isTopLevel);
 
     assertNotUndefined(l3Slice.subSlices);
     assertEquals(1, l3Slice.subSlices.length);
@@ -1311,6 +1326,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertEquals('l4', l4Slice.title);
     assertAlmostEquals(3 / 1000, l4Slice.start);
     assertAlmostEquals(3 / 1000, l4Slice.duration);
+    assertEquals(false, l4Slice.isTopLevel);
 
     assertNotUndefined(l4Slice.subSlices);
     assertEquals(1, l4Slice.subSlices.length);
@@ -1318,6 +1334,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertEquals('l5', l5Slice.title);
     assertAlmostEquals(4 / 1000, l5Slice.start);
     assertAlmostEquals(1 / 1000, l5Slice.duration);
+    assertEquals(false, l5Slice.isTopLevel);
   });
 
   test('nestableAsyncInstantEvent', function() {
@@ -1341,16 +1358,19 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertAlmostEquals(0, instantSlice.start);
     assertAlmostEquals(0, instantSlice.duration);
     assertUndefined(instantSlice.subSlices);
+    assertEquals(true, instantSlice.isTopLevel);
 
     var nestedSlice = t.asyncSliceGroup.slices[1];
     assertEquals('a', nestedSlice.title);
     assertAlmostEquals(0, nestedSlice.start);
     assertAlmostEquals((565 - 524) / 1000, nestedSlice.duration);
+    assertEquals(true, nestedSlice.isTopLevel);
     assertNotUndefined(nestedSlice.subSlices);
     assertEquals(1, nestedSlice.subSlices.length);
     var nestedInstantSlice = nestedSlice.subSlices[0];
     assertUndefined(nestedInstantSlice.subSlices);
     assertEquals('d', nestedInstantSlice.title);
+    assertEquals(false, nestedInstantSlice.isTopLevel);
   });
 
   test('nestableAsyncUnmatchedOuterBeginEvent', function() {
@@ -1372,6 +1392,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     var parentSlice = t.asyncSliceGroup.slices[0];
     assertEquals('a', parentSlice.title);
     assertEquals('foo', parentSlice.category);
+    assertEquals(true, parentSlice.isTopLevel);
     assertAlmostEquals(0, parentSlice.start);
     // Unmatched BEGIN event ends at the last event of that ID.
     assertAlmostEquals(36 / 1000, parentSlice.duration);
@@ -1383,6 +1404,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertNotUndefined(parentSlice.subSlices);
     assertEquals(1, parentSlice.subSlices.length);
     var subSlice = parentSlice.subSlices[0];
+    assertEquals(false, subSlice.isTopLevel);
     assertAlmostEquals(1 / 1000, subSlice.start);
     assertAlmostEquals(35 / 1000, subSlice.duration);
     assertUndefined(subSlice.subSlices);
@@ -1412,6 +1434,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     var parentSlice = t.asyncSliceGroup.slices[0];
     assertEquals('a', parentSlice.title);
     assertEquals('foo', parentSlice.category);
+    assertEquals(true, parentSlice.isTopLevel);
     assertAlmostEquals(0, parentSlice.start);
     assertAlmostEquals(41 / 1000, parentSlice.duration);
     // Arguments should include both BEGIN and END event.
@@ -1424,7 +1447,9 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     var subSliceInstant = parentSlice.subSlices[0];
     var subSliceUnmatched = parentSlice.subSlices[1];
     assertEquals('c', subSliceInstant.title);
+    assertEquals(false, subSliceInstant.isTopLevel);
     assertEquals('b', subSliceUnmatched.title);
+    assertEquals(false, subSliceUnmatched.isTopLevel);
     // Unmatched BEGIN ends at the last event of that ID.
     assertAlmostEquals(1 / 1000, subSliceUnmatched.start);
     assertAlmostEquals(40 / 1000, subSliceUnmatched.duration);
@@ -1458,6 +1483,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     var slice = t.asyncSliceGroup.slices[1];
     assertEquals('a', unmatchedSlice.title);
     assertAlmostEquals(0, unmatchedSlice.start);
+    assertEquals(true, unmatchedSlice.isTopLevel);
     // Unmatched END event begins at the first event of that ID. In this
     // case, the first event happens to be the same unmatched event.
     assertAlmostEquals(0 / 1000, unmatchedSlice.duration);
@@ -1468,6 +1494,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertUndefined(unmatchedSlice.subSlices);
 
     assertEquals('b', slice.title);
+    assertEquals(true, slice.isTopLevel);
     assertAlmostEquals(1 / 1000, slice.start);
     assertAlmostEquals(35 / 1000, slice.duration);
     // Arguments should include both BEGIN and END event.
@@ -1496,6 +1523,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertEquals(1, t.asyncSliceGroup.slices.length);
     var parentSlice = t.asyncSliceGroup.slices[0];
     assertEquals('a', parentSlice.title);
+    assertEquals(true, parentSlice.isTopLevel);
     assertAlmostEquals(0, parentSlice.start);
     assertAlmostEquals(41 / 1000, parentSlice.duration);
     // Arguments should include both BEGIN and END event.
@@ -1507,7 +1535,9 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     var subSliceInstant = parentSlice.subSlices[0];
     var subSliceUnmatched = parentSlice.subSlices[1];
     assertEquals('c', subSliceInstant.title);
+    assertEquals(false, subSliceInstant.isTopLevel);
     assertEquals('b', subSliceUnmatched.title);
+    assertEquals(false, subSliceUnmatched.isTopLevel);
     // Unmatched END begins at the first event of that ID.
     assertAlmostEquals(0 / 1000, subSliceUnmatched.start);
     assertAlmostEquals(1 / 1000, subSliceUnmatched.duration);
@@ -1545,6 +1575,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertEquals('EVENT_A', eventASlice.title);
     assertEquals('foo', eventASlice.category);
     assertEquals('foo:72', eventASlice.id);
+    assertEquals(true, eventASlice.isTopLevel);
     assertEquals(1, eventASlice.args['x']);
     assertUndefined(eventASlice.subSlices);
 
@@ -1552,6 +1583,7 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertEquals('EVENT_B', eventBSlice.title);
     assertEquals('bar', eventBSlice.category);
     assertEquals('bar:72', eventBSlice.id);
+    assertEquals(true, eventBSlice.isTopLevel);
     assertEquals(2, eventBSlice.args['y']);
     assertUndefined(eventBSlice.subSlices);
   });
@@ -2097,14 +2129,17 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     var parentSlice = t.asyncSliceGroup.slices[0];
     assertEquals('a', parentSlice.title);
     assertEquals('foo', parentSlice.category);
+    assertEquals(true, parentSlice.isTopLevel);
 
     assertNotUndefined(parentSlice.subSlices);
     var subSlices = parentSlice.subSlices;
     assertEquals(1000, subSlices.length);
     // Slices should be sorted according to 'ts'. And if 'ts' is the same,
     // slices should keep the order that they were recorded.
-    for (var i = 0; i < 1000; i++)
+    for (var i = 0; i < 1000; i++) {
       assertEquals(subSlices[i].args['seq'], i + 1);
+      assertEquals(false, subSlices[i].isTopLevel);
+    }
   });
 
   test('sampleDataSimple', function() {

--- a/trace_viewer/extras/net/net_async_slice_test.html
+++ b/trace_viewer/extras/net/net_async_slice_test.html
@@ -38,39 +38,50 @@ tv.b.unittest.testSuite(function() {
   test('ExposeURLBasic', function() {
     var slice = new NetAsyncSlice('', 'a', 0, 1,
                                   {params: {url: 'https://google.com'},
-                                   source_type: 'b'});
-    slice.isTopLevel = true;
+                                   source_type: 'b'}, 0, true);
+    // Make sure isTopLevel is populated in the constructor.
+    assertEquals(true, slice.isTopLevel);
+    // URL is exposed as the title of the parent slice.
     assertEquals('https://google.com', slice.title);
   });
 
   test('ExposeURLNested', function() {
     var slice = new NetAsyncSlice(
-        '', 'a', 0, 1, {params: {}, source_type: 'HELLO'});
-    slice.isTopLevel = true;
+        '', 'a', 0, 1, {params: {}, source_type: 'HELLO'}, 1, true);
     var childSlice = new NetAsyncSlice('', 'b', 0, 1,
                                        {params: {url: 'http://test.url'}});
     slice.subSlices = [childSlice];
+    // Make sure isTopLevel is populated in the constructor.
+    assertEquals(true, slice.isTopLevel);
+    assertEquals(false, childSlice.isTopLevel);
+    // URL is exposed as the title of the parent slice.
     assertEquals('http://test.url', slice.title);
     assertEquals('b', childSlice.title);
   });
 
   test('ExposeURLNestedNoURL', function() {
-    var slice = new NetAsyncSlice('', 'a', 0, 1, {params: {}});
-    slice.isTopLevel = true;
+    var slice = new NetAsyncSlice('', 'a', 0, 1, {params: {}}, 1, true);
     var childSlice = new NetAsyncSlice('', 'b', 0, 1, {params: {}});
     slice.subSlices = [childSlice];
+    // Make sure isTopLevel is populated in the constructor.
+    assertEquals(true, slice.isTopLevel);
+    assertEquals(false, childSlice.isTopLevel);
+    // URL is exposed as the title of the parent slice.
     assertEquals('a', slice.title);
     assertEquals('b', childSlice.title);
   });
 
   test('ExposeURLNestedBothChildrenHaveURL', function() {
-    var slice = new NetAsyncSlice('', 'a', 0, 1, {params: {}});
-    slice.isTopLevel = true;
+    var slice = new NetAsyncSlice('', 'a', 0, 1, {params: {}}, 1, true);
     var childSlice1 = new NetAsyncSlice('', 'b', 0, 1,
                                    {params: {url: 'http://test.url.net'}});
     var childSlice2 = new NetAsyncSlice('', 'c', 0, 1,
                                    {params: {url: 'http://test.url.com'}});
     slice.subSlices = [childSlice1, childSlice2];
+    // Make sure isTopLevel is populated in the constructor.
+    assertEquals(true, slice.isTopLevel);
+    assertEquals(false, childSlice1.isTopLevel);
+    assertEquals(false, childSlice2.isTopLevel);
     // Parent should take the first url param that it finds.
     assertEquals('http://test.url.net', slice.title);
     assertEquals('b', childSlice1.title);
@@ -79,13 +90,17 @@ tv.b.unittest.testSuite(function() {
 
   test('ExposeURLNestedBothParentAndChildHaveURL', function() {
     var slice = new NetAsyncSlice('', 'a', 0, 1,
-                                  {params: {url: 'parent123.url.com'}});
-    slice.isTopLevel = true;
+                                  {params: {url: 'parent123.url.com'}}, 1,
+                                  true);
     var childSlice1 = new NetAsyncSlice('', 'b', 0, 1,
                                         {params: {url: 'http://test.url.net'}});
     var childSlice2 = new NetAsyncSlice('', 'c', 0, 1);
 
     slice.subSlices = [childSlice1, childSlice2];
+    // Make sure isTopLevel is populated in the constructor.
+    assertEquals(true, slice.isTopLevel);
+    assertEquals(false, childSlice1.isTopLevel);
+    assertEquals(false, childSlice2.isTopLevel);
     // Parent should take its own url param if there is one.
     assertEquals('parent123.url.com', slice.title);
     assertEquals('b', childSlice1.title);
@@ -93,13 +108,16 @@ tv.b.unittest.testSuite(function() {
   });
 
   test('ExposeURLDoNotComputeUrlTwice', function() {
-    var slice = new NetAsyncSlice('', 'a', 0, 1, {params: {}});
-    slice.isTopLevel = true;
+    var slice = new NetAsyncSlice('', 'a', 0, 1, {params: {}}, 1, true);
     var childSlice1 = new NetAsyncSlice('', 'b', 0, 1,
                                         {params: {url: 'http://test.url.net'}});
     var childSlice2 = new NetAsyncSlice('', 'c', 0, 1);
 
     slice.subSlices = [childSlice1, childSlice2];
+    // Make sure isTopLevel is populated in the constructor.
+    assertEquals(true, slice.isTopLevel);
+    assertEquals(false, childSlice1.isTopLevel);
+    assertEquals(false, childSlice2.isTopLevel);
     // Parent should take its child's url param.
     assertEquals('http://test.url.net', slice.title);
     assertEquals('b', childSlice1.title);
@@ -114,13 +132,17 @@ tv.b.unittest.testSuite(function() {
 
   test('ExposeSourceTypeAsTitle', function() {
     var slice = new NetAsyncSlice('', 'a', 0, 1,
-                                  {params: {}, source_type: 'UDP_SOCKET'});
-    slice.isTopLevel = true;
+                                  {params: {}, source_type: 'UDP_SOCKET'}, 1,
+                                  true);
     var childSlice1 = new NetAsyncSlice('', 'b', 0, 1,
                                         {params: {}, source_type: 'SOCKET'});
     var childSlice2 = new NetAsyncSlice('', 'c', 0, 1);
 
     slice.subSlices = [childSlice1, childSlice2];
+    // Make sure isTopLevel is populated in the constructor.
+    assertEquals(true, slice.isTopLevel);
+    assertEquals(false, childSlice1.isTopLevel);
+    assertEquals(false, childSlice2.isTopLevel);
     // Parent should take its own source_type.
     assertEquals('UDP_SOCKET', slice.title);
     assertEquals('b', childSlice1.title);


### PR DESCRIPTION
Shift the top level slice down, make it shorter, and draw a top border in order to visually separate the slice from events above it. See https://github.com/google/trace-viewer/issues/725 for more details.