### PR TITLE
Implement asynchronous filtering

### DIFF
--- a/trace_viewer/base/task.html
+++ b/trace_viewer/base/task.html
@@ -37,7 +37,7 @@ tv.exportTo('tv.b', function() {
    * @constructor
    */
   function Task(runCb, thisArg) {
-    if (thisArg === undefined)
+    if (runCb !== undefined && thisArg === undefined)
       throw new Error('Almost certainly, you meant to pass a thisArg.');
     this.runCb_ = runCb;
     this.thisArg_ = thisArg;
@@ -61,7 +61,8 @@ tv.exportTo('tv.b', function() {
      * Runs the current task and returns the task that should be executed next.
      */
     run: function() {
-      this.runCb_.call(this.thisArg_, this);
+      if (this.runCb_ !== undefined)
+        this.runCb_.call(this.thisArg_, this);
       var subTasks = this.subTasks_;
       this.subTasks_ = undefined; // Prevent more subTasks from being posted.
 

--- a/trace_viewer/core/find_control.html
+++ b/trace_viewer/core/find_control.html
@@ -55,6 +55,24 @@ found in the LICENSE file.
         width: 170px;
         z-index: 1;
       }
+      #spinner {
+        visibility: hidden;
+        width: 8px;
+        height: 8px;
+        left: 154px;
+        pointer-events: none;
+        position: absolute;
+        top: 4px;
+        z-index: 1;
+
+        border: 2px solid transparent;
+        border-bottom: 2px solid rgba(0, 0, 0, 0.5);
+        border-right: 2px solid rgba(0, 0, 0, 0.5);
+        border-radius: 50%;
+
+        animation: spin 1s linear infinite;
+      }
+      @keyframes spin { 100% { transform: rotate(360deg); } }
     </style>
 
     <div class="root">
@@ -65,6 +83,7 @@ found in the LICENSE file.
           on-blur="{{ filterBlur }}"
           on-focus="{{ filterFocus }}"
           on-mouseup="{{ filterMouseUp }}" />
+      <div id="spinner"></div>
       <div class="button" on-click="{{ findPrevious }}">&larr;</div>
       <div class="button" on-click="{{ findNext }}">&rarr;</div>
       <div id="hitCount">0 of 0</div>
@@ -122,7 +141,12 @@ found in the LICENSE file.
 
     filterTextChanged: function() {
       this.controller.filterText = this.$.filter.value;
-      this.updateHitCountEl();
+      this.$.hitCount.textContent = '';
+      this.$.spinner.style.visibility = 'visible';
+      this.controller.updateFilterHits().then(function() {
+        this.$.spinner.style.visibility = 'hidden';
+        this.updateHitCountEl();
+      }.bind(this));
     },
 
     findNext: function() {

--- a/trace_viewer/core/find_controller.html
+++ b/trace_viewer/core/find_controller.html
@@ -5,6 +5,7 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 -->
 
+<link rel="import" href="/base/task.html">
 <link rel="import" href="/core/filter.html">
 <link rel="import" href="/core/selection.html">
 
@@ -15,6 +16,8 @@ found in the LICENSE file.
  * @fileoverview FindController.
  */
 tv.exportTo('tv.c', function() {
+  var Task = tv.b.Task;
+
   function FindController() {
     this.timeline_ = undefined;
     this.model_ = undefined;
@@ -45,25 +48,43 @@ tv.exportTo('tv.c', function() {
         return;
       this.filterText_ = f;
       this.filterHitsDirty_ = true;
-
-      if (!this.timeline)
-        return;
-
-      this.timeline.setHighlightAndClearSelection(this.filterHits);
     },
 
-    get filterHits() {
-      if (this.filterHitsDirty_) {
-        this.filterHitsDirty_ = false;
-        this.filterHits_ = new tv.c.Selection();
-        this.currentHitIndex_ = -1;
+    /**
+     * Updates the filter hits based on the current filtering settings. Returns
+     * a promise which resolves when |filterHits| has been refreshed.
+     */
+    updateFilterHits: function() {
+      var promise = Promise.resolve();
 
-        if (this.timeline_ && this.filterText.length) {
-          var filter = new tv.c.TitleFilter(this.filterText);
-          this.timeline.addAllObjectsMatchingFilterToSelection(
-              filter, this.filterHits_);
-        }
+      if (!this.filterHitsDirty_)
+        return promise;
+
+      this.filterHits_ = new tv.c.Selection();
+      this.currentHitIndex_ = -1;
+
+      if (this.timeline_ && this.filterText.length) {
+        var filter = new tv.c.TitleFilter(this.filterText);
+        var filterHits = new tv.c.Selection();
+        var filterTask =
+            this.timeline.addAllObjectsMatchingFilterToSelectionAsTask(
+                filter, filterHits);
+        promise = Task.RunWhenIdle(filterTask);
+        promise.then(function() {
+          this.filterHitsDirty_ = false;
+          this.filterHits_ = filterHits;
+          this.timeline.setHighlightAndClearSelection(filterHits);
+        }.bind(this));
       }
+      return promise;
+    },
+
+    /**
+     * Returns the most recent filter hits as a tv.c.Selection. Call
+     * |updateFilterHits| to ensure this is up to date after the filter
+     * settings have been changed.
+     */
+    get filterHits() {
       return this.filterHits_;
     },
 

--- a/trace_viewer/core/find_controller_test.html
+++ b/trace_viewer/core/find_controller_test.html
@@ -5,6 +5,7 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 -->
 
+<link rel="import" href="/base/task.html">
 <link rel="import" href="/core/find_controller.html">
 <link rel="import" href="/core/test_utils.html">
 <link rel="import" href="/core/timeline_track_view.html">
@@ -13,6 +14,8 @@ found in the LICENSE file.
 'use strict';
 
 tv.b.unittest.testSuite(function() {
+  var Task = tv.b.Task;
+
   /*
    * Just enough of the Timeline to support the tests below.
    */
@@ -47,12 +50,14 @@ tv.b.unittest.testSuite(function() {
       this.statusEl_.textContent = status;
     },
 
-    addAllObjectsMatchingFilterToSelection: function(filter, selection) {
-      var n = this.addAllObjectsMatchingFilterToSelectionReturnValue.length;
-      for (var i = 0; i < n; i++) {
-        selection.push(
-            this.addAllObjectsMatchingFilterToSelectionReturnValue[i]);
-      }
+    addAllObjectsMatchingFilterToSelectionAsTask: function(filter, selection) {
+      return new Task(function() {
+        var n = this.addAllObjectsMatchingFilterToSelectionReturnValue.length;
+        for (var i = 0; i < n; i++) {
+          selection.push(
+              this.addAllObjectsMatchingFilterToSelectionReturnValue[i]);
+        }
+      }, this);
     },
 
     setHighlightAndClearSelection: function(highlight) {
@@ -89,18 +94,21 @@ tv.b.unittest.testSuite(function() {
     var s1 = {guid: 1};
     timeline.addAllObjectsMatchingFilterToSelectionReturnValue = [s1];
     controller.filterText = 'asdf';
-
-    assertArrayShallowEquals([], timeline.selection);
-    assertArrayShallowEquals([s1], timeline.highlight);
-    controller.findNext();
-    assertArrayShallowEquals([s1], timeline.selection);
-    assertArrayShallowEquals([s1], timeline.highlight);
-    controller.findNext();
-    assertArrayShallowEquals([s1], timeline.selection);
-    assertArrayShallowEquals([s1], timeline.highlight);
-    controller.findPrevious();
-    assertArrayShallowEquals([s1], timeline.selection);
-    assertArrayShallowEquals([s1], timeline.highlight);
+    var promise = controller.updateFilterHits();
+    promise.then(function() {
+      assertArrayShallowEquals([], timeline.selection);
+      assertArrayShallowEquals([s1], timeline.highlight);
+      controller.findNext();
+      assertArrayShallowEquals([s1], timeline.selection);
+      assertArrayShallowEquals([s1], timeline.highlight);
+      controller.findNext();
+      assertArrayShallowEquals([s1], timeline.selection);
+      assertArrayShallowEquals([s1], timeline.highlight);
+      controller.findPrevious();
+      assertArrayShallowEquals([s1], timeline.selection);
+      assertArrayShallowEquals([s1], timeline.highlight);
+    });
+    return promise;
   });
 
   test('findControllerMultipleHits', function() {
@@ -114,23 +122,26 @@ tv.b.unittest.testSuite(function() {
 
     timeline.addAllObjectsMatchingFilterToSelectionReturnValue = [s1, s2, s3];
     controller.filterText = 'asdf';
-
-    // Loop through hits then when we wrap, try moving backward.
-    assertArrayShallowEquals([], timeline.selection);
-    assertArrayShallowEquals([s1, s2, s3], timeline.highlight);
-    controller.findNext();
-    assertArrayShallowEquals([s1], timeline.selection);
-    controller.findNext();
-    assertArrayShallowEquals([s2], timeline.selection);
-    controller.findNext();
-    assertArrayShallowEquals([s3], timeline.selection);
-    controller.findNext();
-    assertArrayShallowEquals([s1], timeline.selection);
-    controller.findPrevious();
-    assertArrayShallowEquals([s3], timeline.selection);
-    controller.findPrevious();
-    assertArrayShallowEquals([s2], timeline.selection);
-    assertArrayShallowEquals([s1, s2, s3], timeline.highlight);
+    var promise = controller.updateFilterHits();
+    promise.then(function() {
+      // Loop through hits then when we wrap, try moving backward.
+      assertArrayShallowEquals([], timeline.selection);
+      assertArrayShallowEquals([s1, s2, s3], timeline.highlight);
+      controller.findNext();
+      assertArrayShallowEquals([s1], timeline.selection);
+      controller.findNext();
+      assertArrayShallowEquals([s2], timeline.selection);
+      controller.findNext();
+      assertArrayShallowEquals([s3], timeline.selection);
+      controller.findNext();
+      assertArrayShallowEquals([s1], timeline.selection);
+      controller.findPrevious();
+      assertArrayShallowEquals([s3], timeline.selection);
+      controller.findPrevious();
+      assertArrayShallowEquals([s2], timeline.selection);
+      assertArrayShallowEquals([s1, s2, s3], timeline.highlight);
+    });
+    return promise;
   });
 
   test('findControllerChangeFilterAfterNext', function() {
@@ -145,13 +156,20 @@ tv.b.unittest.testSuite(function() {
 
     timeline.addAllObjectsMatchingFilterToSelectionReturnValue = [s1, s2, s3];
     controller.filterText = 'asdf';
+    var promise = controller.updateFilterHits();
+    promise.then(function() {
+      // Loop through hits then when we wrap, try moving backward.
+      controller.findNext();
+      timeline.addAllObjectsMatchingFilterToSelectionReturnValue = [s4];
 
-    // Loop through hits then when we wrap, try moving backward.
-    controller.findNext();
-    timeline.addAllObjectsMatchingFilterToSelectionReturnValue = [s4];
-    controller.filterText = 'asdfsf';
-    controller.findNext();
-    assertArrayShallowEquals([s4], timeline.selection);
+      controller.filterText = 'asdfsf';
+      var nextPromise = controller.updateFilterHits();
+      nextPromise.then(function() {
+        controller.findNext();
+        assertArrayShallowEquals([s4], timeline.selection);
+      });
+    });
+    return promise;
   });
 
   test('findControllerSelectsAllItemsFirst', function() {
@@ -164,13 +182,17 @@ tv.b.unittest.testSuite(function() {
     var s3 = {guid: 3};
     timeline.addAllObjectsMatchingFilterToSelectionReturnValue = [s1, s2, s3];
     controller.filterText = 'asdfsf';
-    assertArrayShallowEquals([], timeline.selection);
-    assertArrayShallowEquals([s1, s2, s3], timeline.highlight);
-    controller.findNext();
-    assertArrayShallowEquals([s1], timeline.selection);
-    controller.findNext();
-    assertArrayShallowEquals([s2], timeline.selection);
-    assertArrayShallowEquals([s1, s2, s3], timeline.highlight);
+    var promise = controller.updateFilterHits();
+    promise.then(function() {
+      assertArrayShallowEquals([], timeline.selection);
+      assertArrayShallowEquals([s1, s2, s3], timeline.highlight);
+      controller.findNext();
+      assertArrayShallowEquals([s1], timeline.selection);
+      controller.findNext();
+      assertArrayShallowEquals([s2], timeline.selection);
+      assertArrayShallowEquals([s1, s2, s3], timeline.highlight);
+    });
+    return promise;
   });
 
   test('findControllerWithRealTimeline', function() {
@@ -191,20 +213,28 @@ tv.b.unittest.testSuite(function() {
 
     // Test find with filter txt.
     controller.filterText = 'a';
-    assertArrayEquals([], timeline.selection);
-    assertArrayEquals(t1.sliceGroup.slices, timeline.highlight);
+    var promise = controller.updateFilterHits();
+    promise.then(function() {
+      assertArrayEquals([], timeline.selection);
+      assertArrayEquals(t1.sliceGroup.slices, timeline.highlight);
 
-    controller.findNext();
-    assertEquals(1, timeline.selection.length);
-    assertEquals(t1.sliceGroup.slices[0], timeline.selection[0]);
+      controller.findNext();
+      assertEquals(1, timeline.selection.length);
+      assertEquals(t1.sliceGroup.slices[0], timeline.selection[0]);
 
-    controller.filterText = 'xxx';
-    assertEquals(0, timeline.highlight.length);
-    assertEquals(0, timeline.selection.length);
-    controller.findNext();
-    assertEquals(0, timeline.selection.length);
-    controller.findNext();
-    assertEquals(0, timeline.selection.length);
+      controller.filterText = 'xxx';
+      var nextPromise = controller.updateFilterHits();
+      nextPromise.then(function() {
+        assertEquals(0, timeline.highlight.length);
+        assertEquals(0, timeline.selection.length);
+        controller.findNext();
+        assertEquals(0, timeline.selection.length);
+        controller.findNext();
+        assertEquals(0, timeline.selection.length);
+      });
+      return nextPromise;
+    });
+    return promise;
   });
 });
 </script>

--- a/trace_viewer/core/timeline_track_view.html
+++ b/trace_viewer/core/timeline_track_view.html
@@ -11,6 +11,7 @@ found in the LICENSE file.
 <link rel="import" href="/base/events.html">
 <link rel="import" href="/base/properties.html">
 <link rel="import" href="/base/settings.html">
+<link rel="import" href="/base/task.html">
 <link rel="import" href="/base/ui.html">
 <link rel="import" href="/base/ui/mouse_mode_selector.html">
 <link rel="import" href="/core/filter.html">
@@ -286,11 +287,10 @@ tv.exportTo('tv.c', function() {
     /**
      * @param {Filter} filter The filter to use for finding matches.
      * @param {Selection} selection The selection to add matches to.
-     * @return {Array} An array of objects that match the provided
-     * TitleFilter.
+     * @return {Task} which performs the filtering.
      */
-    addAllObjectsMatchingFilterToSelection: function(filter, selection) {
-      this.modelTrack_.addAllObjectsMatchingFilterToSelection(
+    addAllObjectsMatchingFilterToSelectionAsTask: function(filter, selection) {
+      return this.modelTrack_.addAllObjectsMatchingFilterToSelectionAsTask(
           filter, selection);
     },
 

--- a/trace_viewer/core/timeline_track_view_test.html
+++ b/trace_viewer/core/timeline_track_view_test.html
@@ -5,6 +5,7 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 -->
 
+<link rel="import" href="/base/task.html">
 <link rel="import" href="/core/test_utils.html">
 <link rel="import" href="/core/timeline_track_view.html">
 <link rel="import" href="/extras/importer/trace_event_importer.html">
@@ -15,6 +16,7 @@ found in the LICENSE file.
 tv.b.unittest.testSuite(function() {
   var Selection = tv.c.Selection;
   var SelectionState = tv.c.trace_model.SelectionState;
+  var Task = tv.b.Task;
 
   function contains(array, element) {
     for (var i = 0; i < array.length; i++) {
@@ -72,7 +74,7 @@ tv.b.unittest.testSuite(function() {
     this.addHTMLOutput(timeline);
   });
 
-  test('addAllObjectsMatchingFilterToSelection', function() {
+  test('addAllObjectsMatchingFilterToSelectionAsTask', function() {
     var model = new tv.c.TraceModel();
     var p1 = model.getOrCreateProcess(1);
     var t1 = p1.getOrCreateThread(1);
@@ -94,8 +96,9 @@ tv.b.unittest.testSuite(function() {
     var expected = [t1asg.slices[0],
                     t1.sliceGroup.slices[0]];
     var result = new tv.c.Selection();
-    timeline.addAllObjectsMatchingFilterToSelection(
+    var filterTask = timeline.addAllObjectsMatchingFilterToSelectionAsTask(
         new tv.c.TitleFilter('a'), result);
+    Task.RunSynchronously(filterTask);
     assertEquals(2, result.length);
     assertEquals(expected[0], result[0]);
     assertEquals(expected[1], result[1]);
@@ -103,8 +106,9 @@ tv.b.unittest.testSuite(function() {
     var expected = [t1asg.slices[1],
                     t1.sliceGroup.slices[1]];
     var result = new tv.c.Selection();
-    timeline.addAllObjectsMatchingFilterToSelection(
+    var filterTask = timeline.addAllObjectsMatchingFilterToSelectionAsTask(
         new tv.c.TitleFilter('b'), result);
+    Task.RunSynchronously(filterTask);
     assertEquals(2, result.length);
     assertEquals(expected[0], result[0]);
     assertEquals(expected[1], result[1]);
@@ -185,12 +189,14 @@ tv.b.unittest.testSuite(function() {
     timeline.model = model;
 
     var selection = new Selection();
-    timeline.addAllObjectsMatchingFilterToSelection(
+    var filterTask = timeline.addAllObjectsMatchingFilterToSelectionAsTask(
         new tv.c.TitleFilter('a'), selection);
+    Task.RunSynchronously(filterTask);
 
     var highlight = new Selection();
-    timeline.addAllObjectsMatchingFilterToSelection(
+    var filterTask = timeline.addAllObjectsMatchingFilterToSelectionAsTask(
         new tv.c.TitleFilter('b'), highlight);
+    Task.RunSynchronously(filterTask);
 
     // Test for faulty input.
     assertThrows(function() {

--- a/trace_viewer/core/timeline_view_test.html
+++ b/trace_viewer/core/timeline_view_test.html
@@ -5,6 +5,7 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 -->
 
+<link rel="import" href="/base/task.html">
 <link rel="import" href="/core/test_utils.html">
 <link rel="import" href="/core/timeline_view.html">
 <link rel="import" href="/core/trace_model/trace_model.html">
@@ -14,6 +15,7 @@ found in the LICENSE file.
 
 tv.b.unittest.testSuite(function() {
   var newSliceNamed = tv.c.test_utils.newSliceNamed;
+  var Task = tv.b.Task;
 
   var createFullyPopulatedModel = function(opt_withError, opt_withMetadata) {
     var withError = opt_withError !== undefined ? opt_withError : true;
@@ -86,19 +88,6 @@ tv.b.unittest.testSuite(function() {
     });
   };
 
-  var buildView = function() {
-    var view = new tv.c.TimelineView();
-    view.model = createFullyPopulatedModel();
-
-    var selection = new tv.c.Selection();
-    view.timeline.addAllObjectsMatchingFilterToSelection({
-      matchSlice: function() { return true; }
-    }, selection);
-    view.timeline.selection = selection;
-
-    return view;
-  };
-
   test('instantiate', function() {
     var model11 = createFullyPopulatedModel(true, true);
 
@@ -137,7 +126,9 @@ tv.b.unittest.testSuite(function() {
     // Verify that the new bits of the model show up in the view.
     var selection = new tv.c.Selection();
     var filter = new tv.c.TitleFilter('somethingUnusual');
-    view.timeline.addAllObjectsMatchingFilterToSelection(filter, selection);
+    var filterTask = view.timeline.addAllObjectsMatchingFilterToSelectionAsTask(
+        filter, selection);
+    Task.RunSynchronously(filterTask);
     assertEquals(selection.length, 1);
   });
 });

--- a/trace_viewer/core/tracks/container_track.html
+++ b/trace_viewer/core/tracks/container_track.html
@@ -5,14 +5,16 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 -->
 
+<link rel="import" href="/base/ui.html">
+<link rel="import" href="/base/task.html">
 <link rel="import" href="/core/tracks/track.html">
 <link rel="import" href="/core/filter.html">
-<link rel="import" href="/base/ui.html">
 
 <script>
 'use strict';
 
 tv.exportTo('tv.c.tracks', function() {
+  var Task = tv.b.Task;
 
   /**
    * A generic track that contains other tracks as its children.
@@ -83,6 +85,17 @@ tv.exportTo('tv.c.tracks', function() {
       for (var i = 0; i < this.tracks_.length; i++)
         this.tracks_[i].addAllObjectsMatchingFilterToSelection(
             filter, selection);
+    },
+
+    addAllObjectsMatchingFilterToSelectionAsTask: function(filter, selection) {
+      var task = new Task();
+      for (var i = 0; i < this.tracks_.length; i++) {
+        task.subTask(function(i) { return function() {
+          this.tracks_[i].addAllObjectsMatchingFilterToSelection(
+              filter, selection);
+        } }(i), this);
+      }
+      return task;
     },
 
     addClosestEventToSelection: function(


### PR DESCRIPTION
This patch changes the find control to use asynchronous tasks instead
of synchronous blocking to find the matching trace events. This lets the
rest of the user interface to update during an on-going search.

Note that this change by itself does not make the UI completely
responsive during searching; constructing the table of results is
another big blocking task that needs to be chopped up.