### PR TITLE
Bind dev server to localhost

### DIFF
--- a/third_party/tvcm/tvcm/dev_server.py
+++ b/third_party/tvcm/tvcm/dev_server.py
@@ -175,7 +175,8 @@ def do_GET_root(request):
 
 class DevServer(SocketServer.ThreadingMixIn, BaseHTTPServer.HTTPServer):
   def __init__(self, port, quiet=False, project=None):
-    BaseHTTPServer.HTTPServer.__init__(self, ('', port), DevServerHandler)
+    BaseHTTPServer.HTTPServer.__init__(
+        self, ('localhost', port), DevServerHandler)
     self._quiet = quiet
     if port == 0:
       port = self.server_address[1]


### PR DESCRIPTION
There's probably no need to make the dev server visible to anything but localhost. This was prompted by a scanner thinking I had a git server at http://hostname:8003/.git/.