### PR TITLE
Add support for importing MemoryDump trace events in TraceEventImporter

### DIFF
--- a/trace_viewer/core/trace_model/global_memory_dump.html
+++ b/trace_viewer/core/trace_model/global_memory_dump.html
@@ -19,10 +19,11 @@ tv.exportTo('tv.c.trace_model', function() {
    * processes.
    * @constructor
    */
-  function GlobalMemoryDump(model, start) {
+  function GlobalMemoryDump(model, start, opt_args) {
     tv.c.trace_model.TimedEvent.call(this, start);
     this.model = model;
     this.processMemoryDumps = {};
+    this.args = opt_args;
   };
 
   GlobalMemoryDump.prototype = {

--- a/trace_viewer/core/trace_model/process_memory_dump.html
+++ b/trace_viewer/core/trace_model/process_memory_dump.html
@@ -18,10 +18,11 @@ tv.exportTo('tv.c.trace_model', function() {
    * The ProcessMemoryDump represents a memory dump of a single process.
    * @constructor
    */
-  function ProcessMemoryDump(globalMemoryDump, process, start) {
+  function ProcessMemoryDump(globalMemoryDump, process, start, opt_args) {
     tv.c.trace_model.TimedEvent.call(this, start);
     this.process = process;
     this.globalMemoryDump = globalMemoryDump;
+    this.args = opt_args;
   };
 
   ProcessMemoryDump.prototype = {

--- a/trace_viewer/extras/importer/trace_event_importer.html
+++ b/trace_viewer/extras/importer/trace_event_importer.html
@@ -6,6 +6,7 @@ found in the LICENSE file.
 -->
 
 <link rel="import" href="/base/quad.html">
+<link rel="import" href="/base/range.html">
 <link rel="import" href="/core/trace_model/trace_model.html">
 <link rel="import" href="/core/color_scheme.html">
 <link rel="import" href="/core/importer/importer.html">
@@ -13,6 +14,8 @@ found in the LICENSE file.
 <link rel="import" href="/core/trace_model/flow_event.html">
 <link rel="import" href="/core/trace_model/counter_series.html">
 <link rel="import" href="/core/trace_model/slice_group.html">
+<link rel="import" href="/core/trace_model/global_memory_dump.html">
+<link rel="import" href="/core/trace_model/process_memory_dump.html">
 
 <script>
 'use strict';
@@ -67,6 +70,9 @@ tv.exportTo('tv.e.importer', function() {
     this.allAsyncEvents_ = [];
     this.allFlowEvents_ = [];
     this.allObjectEvents_ = [];
+
+    // Dump ID -> {global: (event | undefined), process: [events]}
+    this.allMemoryDumpEvents_ = {};
 
     if (typeof(eventData) === 'string' || eventData instanceof String) {
       eventData = eventData.trim();
@@ -406,6 +412,44 @@ tv.exportTo('tv.e.importer', function() {
       this.model_.samples.push(sample);
     },
 
+    getOrCreateMemoryDumpEvents_: function(dumpId) {
+      if (this.allMemoryDumpEvents_[dumpId] === undefined) {
+        this.allMemoryDumpEvents_[dumpId] = {
+          global: undefined,
+          process: []
+        };
+      }
+      return this.allMemoryDumpEvents_[dumpId];
+    },
+
+    processMemoryDumpEvent: function(event) {
+      if (event.id === undefined) {
+        this.model_.importWarning({
+          type: 'memory_dump_parse_error',
+          message: event.ph + ' phase event without a dump ID.'
+        });
+        return;
+      }
+      var events = this.getOrCreateMemoryDumpEvents_(event.id);
+
+      if (event.ph === 'u') {
+        // Add a process memory dump.
+        events.process.push(event);
+      } else if (event.ph === 'U') {
+        // Add a global memory dump (unless already present).
+        if (events.global !== undefined) {
+          this.model_.importWarning({
+            type: 'memory_dump_parse_error',
+            message: 'Multiple U phase events with the same dump ID.'
+          });
+          return;
+        }
+        events.global = event;
+      } else {
+        throw new Error('Invalid memory dump event phase "' + event.ph + '".');
+      }
+    },
+
     /**
      * Walks through the events_ list and outputs the structures discovered to
      * model_.
@@ -444,6 +488,9 @@ tv.exportTo('tv.e.importer', function() {
 
         } else if (event.ph === 's' || event.ph === 't' || event.ph === 'f') {
           this.processFlowEvent(event);
+
+        } else if (event.ph === 'u' || event.ph === 'U') {
+          this.processMemoryDumpEvent(event);
 
         } else {
           this.model_.importWarning({
@@ -503,6 +550,7 @@ tv.exportTo('tv.e.importer', function() {
       this.createFlowSlices_();
       this.createExplicitObjects_();
       this.createImplicitObjects_();
+      this.createMemoryDumps_();
     },
 
     importSampleData: function() {
@@ -1234,6 +1282,52 @@ tv.exportTo('tv.e.importer', function() {
             throw new Error('args cannot have an id field inside it');
           iterObject(snapshot.args, processField, snapshot, this);
         }, this);
+      }, this);
+    },
+
+    createMemoryDumps_: function() {
+      tv.b.iterItems(this.allMemoryDumpEvents_, function(id, events) {
+        // Calculate the range of the global memory dump.
+        var range = new tv.b.Range();
+        if (events.global !== undefined)
+          range.addValue(events.global.ts);
+        for (var i = 0; i < events.process.length; i++)
+          range.addValue(events.process[i].ts);
+
+        // Create the global memory dump.
+        var globalMemoryDump = new tv.c.trace_model.GlobalMemoryDump(
+            this.model_, range.min, this.deepCopyIfNeeded_(events.global));
+        globalMemoryDump.duration = range.range;
+        this.model_.globalMemoryDumps.push(globalMemoryDump);
+
+        // Create individual process memory dumps.
+        if (events.process.length === 0) {
+          this.model_.importWarning({
+              type: 'memory_dump_parse_error',
+              message: 'No process memory dumps associated with global memory' +
+                  ' dump ' + id + '.'
+          });
+        }
+
+        for (var i = 0; i < events.process.length; i++) {
+          var processEvent = events.process[i];
+          var pid = processEvent.pid;
+          if (pid in globalMemoryDump.processMemoryDumps) {
+            this.model_.importWarning({
+              type: 'memory_dump_parse_error',
+              message: 'Multiple process memory dumps with pid=' + pid +
+                  ' for dump id ' + id + '.'
+            });
+            continue;
+          }
+
+          var process = this.model_.getOrCreateProcess(pid);
+          var processMemoryDump = new tv.c.trace_model.ProcessMemoryDump(
+              globalMemoryDump, process, processEvent.ts,
+              this.deepCopyIfNeeded_(processEvent.args));
+          process.memoryDumps.push(processMemoryDump);
+          globalMemoryDump.processMemoryDumps[pid] = processMemoryDump;
+        }
       }, this);
     },
 

--- a/trace_viewer/extras/importer/trace_event_importer_test.html
+++ b/trace_viewer/extras/importer/trace_event_importer_test.html
@@ -2056,6 +2056,52 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertEquals(1, m.samples[0].weight);
   });
 
+  test('importMemoryDumps', function() {
+    var events = [
+      // 2 process memory dump events without a global memory dump event.
+      {name: 'a', pid: 42, ts: 10, cat: 'test', tid: 53, ph: 'u', 'id': 'dump1', args: {}},  // @suppress longLineCheck
+      {name: 'b', pid: 43, ts: 11, cat: 'test', tid: 54, ph: 'u', 'id': 'dump1', args: {}},  // @suppress longLineCheck
+      // 1 global memory dump event and 1 process memory dump event.
+      {name: 'c', pid: 44, ts: 12, cat: 'test', tid: 55, ph: 'U', 'id': 'dump2', args: {}},  // @suppress longLineCheck
+      {name: 'd', pid: 42, ts: 13, cat: 'test', tid: 56, ph: 'u', 'id': 'dump2', args: {}}  // @suppress longLineCheck
+    ];
+    var m = new tv.c.TraceModel(events, false);
+    var p1 = m.getProcess(42);
+    var p2 = m.getProcess(43);
+    assertNotUndefined(p1);
+    assertNotUndefined(p2);
+
+    // Check that TraceModel and Process objects contain the right dumps.
+    assertEquals(2, m.globalMemoryDumps.length);
+    assertEquals(2, p1.memoryDumps.length);
+    assertEquals(1, p2.memoryDumps.length);
+
+    assertEquals(10, m.globalMemoryDumps[0].start);
+    assertEquals(10, p1.memoryDumps[0].start);
+    assertEquals(11, p2.memoryDumps[0].start);
+    assertEquals(1, m.globalMemoryDumps[0].duration);
+    assertEquals(0, p1.memoryDumps[0].duration);
+    assertEquals(0, p2.memoryDumps[0].duration);
+
+    assertEquals(12, m.globalMemoryDumps[1].start);
+    assertEquals(13, p1.memoryDumps[1].start);
+    assertEquals(1, m.globalMemoryDumps[1].duration);
+    assertEquals(0, p1.memoryDumps[1].duration);
+
+    // Check that GlobalMemoryDump and ProcessMemoryDump objects are
+    // interconnected correctly.
+    assertEquals(m.globalMemoryDumps[0].processMemoryDumps[42],
+        p1.memoryDumps[0]);
+    assertEquals(m.globalMemoryDumps[0].processMemoryDumps[43],
+        p2.memoryDumps[0]);
+    assertEquals(m.globalMemoryDumps[0], p1.memoryDumps[0].globalMemoryDump);
+    assertEquals(m.globalMemoryDumps[0], p2.memoryDumps[0].globalMemoryDump);
+
+    assertEquals(m.globalMemoryDumps[1].processMemoryDumps[42],
+        p1.memoryDumps[1]);
+    assertEquals(m.globalMemoryDumps[1], p1.memoryDumps[1].globalMemoryDump);
+  });
+
   // TODO(nduca): one slice, two threads
   // TODO(nduca): one slice, two pids
 


### PR DESCRIPTION
This patch is the *second step* towards implementing memory dumps in Trace Viewer (follow-up for #740).