### PR TITLE
Change memory dump event phase to v/V

### DIFF
--- a/trace_viewer/extras/importer/trace_event_importer.html
+++ b/trace_viewer/extras/importer/trace_event_importer.html
@@ -441,15 +441,15 @@ tv.exportTo('tv.e.importer', function() {
       }
       var events = this.getOrCreateMemoryDumpEvents_(event.id);
 
-      if (event.ph === 'u') {
+      if (event.ph === 'v') {
         // Add a process memory dump.
         events.process.push(event);
-      } else if (event.ph === 'U') {
+      } else if (event.ph === 'V') {
         // Add a global memory dump (unless already present).
         if (events.global !== undefined) {
           this.model_.importWarning({
             type: 'memory_dump_parse_error',
-            message: 'Multiple U phase events with the same dump ID.'
+            message: 'Multiple V phase events with the same dump ID.'
           });
           return;
         }
@@ -501,7 +501,7 @@ tv.exportTo('tv.e.importer', function() {
         } else if (event.ph === 's' || event.ph === 't' || event.ph === 'f') {
           this.processFlowEvent(event);
 
-        } else if (event.ph === 'u' || event.ph === 'U') {
+        } else if (event.ph === 'v' || event.ph === 'V') {
           this.processMemoryDumpEvent(event);
 
         } else {

--- a/trace_viewer/extras/importer/trace_event_importer_test.html
+++ b/trace_viewer/extras/importer/trace_event_importer_test.html
@@ -2138,11 +2138,11 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
   test('importMemoryDumps', function() {
     var events = [
       // 2 process memory dump events without a global memory dump event.
-      {name: 'a', pid: 42, ts: 10, cat: 'test', tid: 53, ph: 'u', 'id': 'dump1', args: {}},  // @suppress longLineCheck
-      {name: 'b', pid: 43, ts: 11, cat: 'test', tid: 54, ph: 'u', 'id': 'dump1', args: {}},  // @suppress longLineCheck
+      {name: 'a', pid: 42, ts: 10, cat: 'test', tid: 53, ph: 'v', 'id': 'dump1', args: {}},  // @suppress longLineCheck
+      {name: 'b', pid: 43, ts: 11, cat: 'test', tid: 54, ph: 'v', 'id': 'dump1', args: {}},  // @suppress longLineCheck
       // 1 global memory dump event and 1 process memory dump event.
-      {name: 'c', pid: 44, ts: 12, cat: 'test', tid: 55, ph: 'U', 'id': 'dump2', args: {}},  // @suppress longLineCheck
-      {name: 'd', pid: 42, ts: 13, cat: 'test', tid: 56, ph: 'u', 'id': 'dump2', args: {}}  // @suppress longLineCheck
+      {name: 'c', pid: 44, ts: 12, cat: 'test', tid: 55, ph: 'V', 'id': 'dump2', args: {}},  // @suppress longLineCheck
+      {name: 'd', pid: 42, ts: 13, cat: 'test', tid: 56, ph: 'v', 'id': 'dump2', args: {}}  // @suppress longLineCheck
     ];
     var m = new tv.c.TraceModel(events, false);
     var p1 = m.getProcess(42);


### PR DESCRIPTION
This patch changes the phases of memory dump events from **u**/**U** to **v**/**V** to avoid conflict with <tt>TRACE_EVENT_PHASE_MEASURE</tt> in Blink.