### PR TITLE
Modified preset categories not getting included in the recorded trace

### DIFF
--- a/trace_viewer/extras/about_tracing/record_selection_dialog.html
+++ b/trace_viewer/extras/about_tracing/record_selection_dialog.html
@@ -311,7 +311,8 @@ tv.exportTo('tv.e.about_tracing', function() {
     },
 
     usingPreset_: function() {
-      return this.currentlyChosenPreset_.length > 0;
+      return this.currentlyChosenPreset_.length > 0 ||
+             this.isPresetSelected_;
     },
 
     get currentlyChosenPreset() {
@@ -323,8 +324,10 @@ tv.exportTo('tv.e.about_tracing', function() {
         throw new Error('RecordSelectionDialog.currentlyChosenPreset:' +
             ' preset must be an array.');
       this.currentlyChosenPreset_ = preset;
+      this.isPresetSelected_ = false;
 
       if (this.currentlyChosenPreset_.length) {
+        this.isPresetSelected_ = true;
         this.changeEditCategoriesState_(false);
       } else {
         this.updateCategoryColumnView_(true);
@@ -360,7 +363,7 @@ tv.exportTo('tv.e.about_tracing', function() {
     },
 
     onClickEditCategories: function() {
-      if (!this.currentlyChosenPreset_.length)
+      if (!this.usingPreset_())
         return;
 
       if (!this.editCategoriesOpened_) {
@@ -557,7 +560,13 @@ tv.exportTo('tv.e.about_tracing', function() {
       // Change the current record mode to 'Manually select settings' from
       // preset mode if and only if currently user is in preset record mode
       // and user selects/deselects any category in 'Edit Categories' mode.
-      if (this.currentlyChosenPreset_.length) {
+      if (this.usingPreset_()) {
+        if (checkbox.checked) {
+          this.currentlyChosenPreset_.push(checkbox.value);
+        } else {
+          var pos = this.currentlyChosenPreset_.lastIndexOf(checkbox.value);
+          this.currentlyChosenPreset_.splice(pos, 1);
+        }
         var categoryEl = document.getElementById(
             'category-preset-Manually-select-settings');
         categoryEl.checked = true;


### PR DESCRIPTION
When recording with preset modes ex. Frame Viewer, after choosing
Edit categories, newly selected/deselected categories ex 'blink.invalidation'
doesn't get recorded or removed from the recorded trace. We are not
updating the currentChosenPreset_ array with updated values.

BUG=758