### PR TITLE
Depecate net category and promote netlog category

### DIFF
--- a/trace_viewer/extras/about_tracing/record_selection_dialog.html
+++ b/trace_viewer/extras/about_tracing/record_selection_dialog.html
@@ -162,8 +162,8 @@ tv.exportTo('tv.e.about_tracing', function() {
 
   var DEFAULT_PRESETS = [
     {title: 'Web developer',
-      categoryFilter: ['blink', 'cc', 'net', 'renderer.scheduler', 'toplevel',
-        'v8']},
+      categoryFilter: ['blink', 'cc', 'netlog', 'renderer.scheduler',
+        'toplevel', 'v8']},
     {title: 'Input latency',
       categoryFilter: ['benchmark', 'input', 'renderer.scheduler', 'toplevel']},
     {title: 'Rendering',


### PR DESCRIPTION
This CL replaces "net" category in "Web develop" preset with "netlog" category. This is a part of the effort to deprecate the "net" category and promote "netlog" category. For more information, see crbug.com/456114
and crrev.com/931343002.