### PR TITLE
Remove the record selection dialog inner scrollbars

### DIFF
--- a/trace_viewer/extras/about_tracing/record_selection_dialog.html
+++ b/trace_viewer/extras/about_tracing/record_selection_dialog.html
@@ -16,7 +16,6 @@ found in the LICENSE file.
     display: -webkit-flex;
     -webkit-flex-direction: column;
     font-family: sans-serif;
-    max-height: 420px;
     max-width: 640px;
     min-height: 0;
     min-width: 0;
@@ -99,8 +98,6 @@ found in the LICENSE file.
   .categories {
     font-size: 80%;
     padding: 10px;
-    overflow: auto;
-    max-height: 400px;
     -webkit-flex: 1 1 auto;
   }
 


### PR DESCRIPTION
Two set of scrollbars are shown currently - one for record selection
dialog and other for category list (in manual selection mode).
Ideally, we need not have separate scrollbars for category list view.
The scrollbar for recording dialog serves the purpose for category
list view also.

BUG=#702