### PR TITLE
Fix selection colouring

### DIFF
--- a/trace_viewer/base/ui/color_scheme.html
+++ b/trace_viewer/base/ui/color_scheme.html
@@ -84,7 +84,7 @@ tv.exportTo('tv.b.ui', function() {
   })();
   var palette = paletteRaw.map(colorToRGBString);
 
-  var highlightIdBoost = palette.length;
+  var highlightIdBoost = palette.length / 2;
 
   // Build reservedColorNameToIdMap.
   var reservedColorNameToIdMap = (function() {


### PR DESCRIPTION
Colours when highlighting a selection was broken previously -- incorrect
colours were displayed. There were also an error when selecting any
counter track which causes the timeline to mess up completely (tracks
after that counter track randomly starts disappearing, etc.).