### PR TITLE
Fix zoom animation's affectsPanY()

### DIFF
--- a/trace_viewer/core/timeline_display_transform_animations.html
+++ b/trace_viewer/core/timeline_display_transform_animations.html
@@ -124,14 +124,13 @@ tv.exportTo('tv.c', function() {
     this.startScaleX = undefined;
     this.goalScaleX = undefined;
     this.startPanY = undefined;
-    this.goalPanY = undefined;
   }
 
   TimelineDisplayTransformZoomToAnimation.prototype = {
     __proto__: tv.b.ui.Animation.prototype,
 
     get affectsPanY() {
-      return this.startPanY != this.goalPanY;
+      return this.startPanY != this.goalFocalPointY;
     },
 
     canTakeOverFor: function(existingAnimation) {

--- a/trace_viewer/core/timeline_display_transform_animations_test.html
+++ b/trace_viewer/core/timeline_display_transform_animations_test.html
@@ -25,17 +25,37 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
       return this.clone();
     };
 
-    var a = new TimelineDisplayTransformPanAnimation(10, 0, 100);
+    var a = new TimelineDisplayTransformPanAnimation(10, 20, 100);
 
     var controller = new tv.b.ui.AnimationController();
     controller.target = target;
     controller.queueAnimation(a, 0);
 
+    assertTrue(a.affectsPanY);
     tv.b.forcePendingRAFTasksToRun(50);
     assertTrue(target.panX > 0);
     tv.b.forcePendingRAFTasksToRun(100);
     assertFalse(controller.hasActiveAnimation);
     assertEquals(10, target.panX);
+    assertEquals(20, target.panY);
+  });
+
+  test('zoomBasic', function() {
+    var target = new TimelineDisplayTransform();
+    target.panY = 30;
+    target.cloneAnimationState = function() {
+      return this.clone();
+    };
+
+    var a = new TimelineDisplayTransformZoomToAnimation(10, 20, 30, 5, 100);
+
+    var controller = new tv.b.ui.AnimationController();
+    controller.target = target;
+    controller.queueAnimation(a, 0);
+
+    assertFalse(a.affectsPanY);
+    tv.b.forcePendingRAFTasksToRun(100);
+    assertEquals(5, target.scaleX);
   });
 
   test('panTakeover', function() {


### PR DESCRIPTION
affectsPanY() would always return true because this.goalPanY is never
assigned a value. I believe this.goalFocalPointY was the intended
variable to be used.

This is not a visible issue since currently affectsPanY() is only
used in the viewport to stop active animations if an onScroll event is
invoked. If the zoom animation truly did affect panY the animation would
be cancelled there anyway. Nevertheless I believe it's still worth fixing.

I only found this issue when trying to animate panY for my
NavUsingFindController feature.

Transform animation unit tests' coverage has been improved to test
for this as well.