### PR TITLE
sort nestable async events using event.cat + ':' + event.id

### DIFF
--- a/trace_viewer/extras/importer/trace_event_importer.html
+++ b/trace_viewer/extras/importer/trace_event_importer.html
@@ -677,7 +677,7 @@ tv.exportTo('tv.e.importer', function() {
       var legacyEvents = [];
       // Group nestable async events by ID. Events with the same ID should
       // belong to the same parent async event.
-      var nestableAsyncEventsByID = {};
+      var nestableAsyncEventsByKey = {};
       for (var i = 0; i < this.allAsyncEvents_.length; i++) {
         var asyncEventState = this.allAsyncEvents_[i];
         var event = asyncEventState.event;
@@ -686,6 +686,15 @@ tv.exportTo('tv.e.importer', function() {
           legacyEvents.push(asyncEventState);
           continue;
         }
+        if (event.cat === undefined) {
+          this.model_.importWarning({
+            type: 'async_slice_parse_error',
+            message: 'Nestable async events (ph: b, e, or n) require a ' +
+                'cat parameter.'
+          });
+          continue;
+        }
+
         if (event.name === undefined) {
           this.model_.importWarning({
             type: 'async_slice_parse_error',
@@ -695,8 +704,7 @@ tv.exportTo('tv.e.importer', function() {
           continue;
         }
 
-        var id = event.id;
-        if (id === undefined) {
+        if (event.id === undefined) {
           this.model_.importWarning({
             type: 'async_slice_parse_error',
             message: 'Nestable async events (ph: b, e, or n) require an ' +
@@ -704,16 +712,17 @@ tv.exportTo('tv.e.importer', function() {
           });
           continue;
         }
-        if (nestableAsyncEventsByID[id] === undefined)
-           nestableAsyncEventsByID[id] = [];
-        nestableAsyncEventsByID[id].push(asyncEventState);
+        var key = event.cat + ':' + event.id;
+        if (nestableAsyncEventsByKey[key] === undefined)
+           nestableAsyncEventsByKey[key] = [];
+        nestableAsyncEventsByKey[key].push(asyncEventState);
       }
       // Handle legacy async events.
       this.createLegacyAsyncSlices_(legacyEvents);
 
       // Parse nestable async events into AsyncSlices.
-      for (var id in nestableAsyncEventsByID) {
-        var eventStateEntries = nestableAsyncEventsByID[id];
+      for (var key in nestableAsyncEventsByKey) {
+        var eventStateEntries = nestableAsyncEventsByKey[key];
         // Stack of enclosing BEGIN events.
         var parentStack = [];
         for (var i = 0; i < eventStateEntries.length; ++i) {
@@ -825,7 +834,7 @@ tv.exportTo('tv.e.importer', function() {
 
           slice.startThread = startState.thread;
           slice.endThread = endState.thread;
-          slice.id = id;
+          slice.id = key;
           if (sliceError !== undefined)
             slice.error = sliceError;
           eventStateEntry.slice = slice;

--- a/trace_viewer/extras/importer/trace_event_importer_test.html
+++ b/trace_viewer/extras/importer/trace_event_importer_test.html
@@ -1523,6 +1523,39 @@ tv.b.unittest.testSuite(function() { // @suppress longLineCheck
     assertUndefined(subSliceInstant.subSlices);
   });
 
+  test('nestableAsyncSameIDDifferentCategory', function() {
+    // Events with the same ID, but different categories should not be
+    // considered as nested.
+    var events = [
+      {name: 'EVENT_A', args: {}, pid: 52, ts: 500, cat: 'foo', tid: 53,
+        ph: 'b', id: 72},
+      {name: 'EVENT_B', args: {y: 2}, pid: 52, ts: 550, cat: 'bar', tid: 53,
+        ph: 'b', id: 72},
+      {name: 'EVENT_B', args: {}, pid: 52, ts: 600, cat: 'bar', tid: 53,
+        ph: 'e', id: 72},
+      {name: 'EVENT_A', args: {x: 1}, pid: 52, ts: 650, cat: 'foo', tid: 53,
+        ph: 'e', id: 72}
+    ];
+
+    var m = new tv.c.TraceModel(events);
+    var t = m.processes[52].threads[53];
+    assertNotUndefined(t);
+    assertEquals(2, t.asyncSliceGroup.slices.length);
+    var eventASlice = t.asyncSliceGroup.slices[0];
+    assertEquals('EVENT_A', eventASlice.title);
+    assertEquals('foo', eventASlice.category);
+    assertEquals('foo:72', eventASlice.id);
+    assertEquals(1, eventASlice.args['x']);
+    assertUndefined(eventASlice.subSlices);
+
+    var eventBSlice = t.asyncSliceGroup.slices[1];
+    assertEquals('EVENT_B', eventBSlice.title);
+    assertEquals('bar', eventBSlice.category);
+    assertEquals('bar:72', eventBSlice.id);
+    assertEquals(2, eventBSlice.args['y']);
+    assertUndefined(eventBSlice.subSlices);
+  });
+
   test('importSamples', function() {
     var events = [
       {name: 'a', args: {}, pid: 52, ts: 548, cat: 'test', tid: 53, ph: 'P'},


### PR DESCRIPTION
This commit is to address https://github.com/google/trace-viewer/issues/765. This change sorts nestable async events using event.cat + ':' + event.id as the key. Importer logic on the legacy async events is not modified, since legacy logic does not group events solely by their IDs. To make sure this change works, the unit test added in this commit tests whether the importer incorrectly groups two nestable async events (with different categories but the same IDs) together. The test does fail without this change.
