### PR TITLE
Display the new op info structures.

### DIFF
--- a/trace_viewer/extras/cc/picture_ops_list_view.html
+++ b/trace_viewer/extras/cc/picture_ops_list_view.html
@@ -90,12 +90,13 @@ tv.exportTo('tv.e.cc', function() {
           item.appendChild(elementInfo);
         }
 
-        // Display each of the Skia ops.
-        op.info.forEach(function(info) {
+        // Display the Skia params.
+        // FIXME: now that we have structured data, we should format it.
+        if (op.info.length > 0) {
           var infoItem = document.createElement('div');
-          infoItem.textContent = info;
+          infoItem.textContent = JSON.stringify(op.info);
           item.appendChild(infoItem);
-        });
+        }
 
         // Display the op timing, if available.
         if (op.cmd_time && op.cmd_time >= 0.0001) {

--- a/trace_viewer/extras/cc/picture_ops_list_view.html
+++ b/trace_viewer/extras/cc/picture_ops_list_view.html
@@ -92,6 +92,7 @@ tv.exportTo('tv.e.cc', function() {
 
         // Display the Skia params.
         // FIXME: now that we have structured data, we should format it.
+        // (https://github.com/google/trace-viewer/issues/782)
         if (op.info.length > 0) {
           var infoItem = document.createElement('div');
           infoItem.textContent = JSON.stringify(op.info);


### PR DESCRIPTION
After http://crrev.com/942533002/, SkiaBenchmarkingExtension op info is no longer a flat string - but an object hierarchy. There are probably much better ways to present it, but this is a quick hack to display the information.
