### PR TITLE
Improve display of slice totals

### DIFF
--- a/trace_viewer/core/analysis/analysis_results.html
+++ b/trace_viewer/core/analysis/analysis_results.html
@@ -228,24 +228,30 @@ tv.exportTo('tv.c.analysis', function() {
      * the third.
      *
      * @param {object=} opt_statistics May be undefined, or an object which
-     *          contains calculated staistics containing min/max/avg for slices,
-     *          or min/max/avg/start/end for counters.
+     *          contains calculated statistics containing min/max/avg for
+     *          slices, or min/max/avg/start/end for counters.
      */
     appendDetailsRow: function(table, start, duration, selfTime, args,
-        opt_selectionGenerator, opt_cpuDuration) {
-      var row = this.appendBodyRow(table);
-
-      if (opt_selectionGenerator) {
-        var labelEl = this.appendTableCell(table, row,
-                                           tv.c.analysis.tsRound(start));
-        labelEl.textContent = '';
-        labelEl.appendChild(this.createSelectionChangingLink(
-                                    tv.c.analysis.tsRound(start),
-                                    opt_selectionGenerator, ''));
-      } else {
-        this.appendTableCell(table, row, tv.c.analysis.tsRound(start));
+        opt_selectionGenerator, opt_cpuDuration, opt_inFoot) {
+      if (opt_inFoot) {
+        // If inFoot is true, then we're reporting Totals.
+        var row = this.appendFootRow(table);
+        this.appendTableCell(table, row, 'Totals');
       }
+      else {
+        var row = this.appendBodyRow(table);
 
+        if (opt_selectionGenerator) {
+          var labelEl = this.appendTableCell(table, row,
+                                             tv.c.analysis.tsRound(start));
+          labelEl.textContent = '';
+          labelEl.appendChild(this.createSelectionChangingLink(
+                                      tv.c.analysis.tsRound(start),
+                                      opt_selectionGenerator, ''));
+        } else {
+          this.appendTableCell(table, row, tv.c.analysis.tsRound(start));
+        }
+      }
       if (duration !== null)
         this.appendTableCell(table, row, tv.c.analysis.tsRound(duration));
 
@@ -284,7 +290,7 @@ tv.exportTo('tv.c.analysis', function() {
      * |occurrences| in the third.
      *
      * @param {object=} opt_statistics May be undefined, or an object which
-     *          contains calculated staistics containing min/max/avg for slices,
+     *          contains calculated statistics containing min/max/avg for slices,
      *          or min/max/avg/start/end for counters.
      */
     appendDataRow: function(table, label, opt_duration, opt_cpuDuration,

--- a/trace_viewer/core/analysis/multi_slice_sub_view.html
+++ b/trace_viewer/core/analysis/multi_slice_sub_view.html
@@ -60,16 +60,40 @@ found in the LICENSE file.
       results.appendTableCell(table, row, 'Args');
 
       var numSlices = 0;
+      var totalArg = {};
+      var totalDuration = 0;
+      var totalSelfTime = 0;
+      var totalCpuDuration = 0;
       tv.b.iterItems(sliceGroup, function(title, slice) {
         numSlices++;
         results.appendDetailsRow(table, slice.start, slice.duration,
             slice.selfTime ? slice.selfTime : slice.duration, slice.args,
             function() {
               return new tv.c.Selection([slice]);
-            }, slice.cpuDuration);
+            }, slice.cpuDuration, false);
+
+        // Track numeric totals to report at the foot.
+        totalDuration += slice.duration;
+        totalSelfTime += slice.selfTime ? slice.selfTime : slice.duration;
+        if (hasCpuDuration)
+          totalCpuDuration += slice.cpuDuration;
+        for (var argName in slice.args) {
+          var argVal = slice.args[argName];
+          var type = (typeof argVal);
+          if (type == 'number') {
+            if (totalArg[argName] == null)
+              totalArg[argName] = 0;
+            totalArg[argName] += argVal;
+          }
+        }
+
       });
-      if (numSlices > 1)
+      if (numSlices > 1) {
+        results.appendDetailsRow(table, undefined, totalDuration, totalSelfTime,
+            totalArg, undefined, hasCpuDuration ? totalCpuDuration : undefined,
+            true);
         tv.b.ui.SortableTable.decorate(table);
+      }
     },
 
     analyzeMultipleSlices_: function(results, slices) {

--- a/trace_viewer/core/analysis/multi_slice_sub_view_test.html
+++ b/trace_viewer/core/analysis/multi_slice_sub_view_test.html
@@ -21,6 +21,7 @@ tv.b.unittest.testSuite(function() {
   var StubAnalysisResults = tv.c.analysis.StubAnalysisResults;
   var newSliceNamed = tv.c.test_utils.newSliceNamed;
   var newSliceCategory = tv.c.test_utils.newSliceCategory;
+  var Slice = tv.c.trace_model.Slice;
 
   var createSelectionWithTwoSlices = function() {
     var model = new Model();
@@ -54,7 +55,90 @@ tv.b.unittest.testSuite(function() {
     return selection;
   };
 
-    test('instantiate_withMultipleSlices', function() {
+  var createSelectionWithOneArg = function() {
+    var model = new Model();
+    var t53 = model.getOrCreateProcess(52).getOrCreateThread(53);
+    t53.sliceGroup.pushSlice(new Slice('', 'c', 0, 0.0, {'arg1': 3.14}, 0.04));
+    t53.sliceGroup.pushSlice(new Slice('', 'c', 0, 0.12, {'arg1': 6.28}, 0.06));
+
+    var t53track = {};
+    t53track.thread = t53;
+
+    var selection = new Selection();
+    selection.push(t53.sliceGroup.slices[0]);
+    selection.push(t53.sliceGroup.slices[1]);
+
+    return selection;
+  };
+
+  var createSelectionWithOneNumberOneTextArg = function() {
+    var model = new Model();
+    var t53 = model.getOrCreateProcess(52).getOrCreateThread(53);
+    t53.sliceGroup.pushSlice(new Slice('', 'c', 0, 0.0,
+        {'arg1': 3.14, 'arg2': 'text1'}, 0.04));
+    t53.sliceGroup.pushSlice(new Slice('', 'c', 0, 0.12,
+        {'arg1': 6.28, 'arg2': 'text2'}, 0.06));
+
+    var t53track = {};
+    t53track.thread = t53;
+
+    var selection = new Selection();
+    selection.push(t53.sliceGroup.slices[0]);
+    selection.push(t53.sliceGroup.slices[1]);
+
+    return selection;
+  };
+
+  var createSelectionWithTwoNumberArgs = function() {
+    var model = new Model();
+    var t53 = model.getOrCreateProcess(52).getOrCreateThread(53);
+    t53.sliceGroup.pushSlice(new Slice('', 'c', 0, 0.0,
+        {'arg1': 3.14, 'arg2': 200.0}, 0.04));
+    t53.sliceGroup.pushSlice(new Slice('', 'c', 0, 0.12,
+        {'arg1': 6.28, 'arg2': 100.0}, 0.06));
+
+    var t53track = {};
+    t53track.thread = t53;
+
+    var selection = new Selection();
+    selection.push(t53.sliceGroup.slices[0]);
+    selection.push(t53.sliceGroup.slices[1]);
+
+    return selection;
+  };
+
+  var createSelectionWithMismatchedArgs = function() {
+    var model = new Model();
+    var t53 = model.getOrCreateProcess(52).getOrCreateThread(53);
+    // Two numbers
+    t53.sliceGroup.pushSlice(new Slice('', 'c', 0, 0.0,
+        {'arg1': 3.14, 'arg2': 200.0}, 0.04));
+    t53.sliceGroup.pushSlice(new Slice('', 'c', 0, 0.12,
+        {'arg1': 6.28, 'arg2': 100.0}, 0.06));
+    // One number, missing arg1.
+    t53.sliceGroup.pushSlice(new Slice('', 'c', 0, 0.14,
+        {'arg2': 50.0}, 0.08));
+    // One number, arg2 is not numeric.
+    t53.sliceGroup.pushSlice(new Slice('', 'c', 0, 0.17,
+        {'arg1': 1.0, 'arg2': 'text'}, 0.1));
+    // Missing both args.
+    t53.sliceGroup.pushSlice(new Slice('', 'c', 0, 0.19,
+        {}, 0.12));
+
+    var t53track = {};
+    t53track.thread = t53;
+
+    var selection = new Selection();
+    selection.push(t53.sliceGroup.slices[0]);
+    selection.push(t53.sliceGroup.slices[1]);
+    selection.push(t53.sliceGroup.slices[2]);
+    selection.push(t53.sliceGroup.slices[3]);
+    selection.push(t53.sliceGroup.slices[4]);
+
+    return selection;
+  };
+
+  test('instantiate_withMultipleSlices', function() {
     var selection = createSelectionWithTwoSlices();
 
     var analysisEl = new TracingAnalysisView();
@@ -70,6 +154,37 @@ tv.b.unittest.testSuite(function() {
     this.addHTMLOutput(analysisEl);
   });
 
+  test('instantiate_withMultipleSlicesOneArg', function() {
+    var selection = createSelectionWithOneArg();
+
+    var analysisEl = new TracingAnalysisView();
+    analysisEl.selection = selection;
+    this.addHTMLOutput(analysisEl);
+  });
+
+  test('instantiate_withMultipleSlicesOneNumberOneTextArg', function() {
+    var selection = createSelectionWithOneNumberOneTextArg();
+
+    var analysisEl = new TracingAnalysisView();
+    analysisEl.selection = selection;
+    this.addHTMLOutput(analysisEl);
+  });
+
+  test('instantiate_withMultipleSlicesTwoNumberArgs', function() {
+    var selection = createSelectionWithTwoNumberArgs();
+
+    var analysisEl = new TracingAnalysisView();
+    analysisEl.selection = selection;
+    this.addHTMLOutput(analysisEl);
+  });
+
+  test('instantiate_withMultipleSlicesMismatchedArgs', function() {
+    var selection = createSelectionWithMismatchedArgs();
+
+    var analysisEl = new TracingAnalysisView();
+    analysisEl.selection = selection;
+    this.addHTMLOutput(analysisEl);
+  });
 
   test('analyzeSelectionWithTwoSlices', function() {
     var selection = createSelectionWithTwoSlices();
@@ -152,6 +267,84 @@ tv.b.unittest.testSuite(function() {
           args: {}
         },
         t.rows[1]);
+    assertObjectEquals(
+        { duration: 0.1,
+          selfTime: 0.1,
+          args: {}
+        },
+        t.rows[2]);
+  });
+
+  test('analyzeSelectionTotalWithOneArg', function() {
+    var selection = createSelectionWithOneArg();
+
+    var sliceView = document.createElement('tv-c-multi-slice-sub-view');
+    var results = new StubAnalysisResults();
+    sliceView.analyzeMultipleSlices_(results, selection, 'Slices');
+    assertEquals(2, results.tables.length);
+
+    var t = results.tables[1];
+
+    assertObjectEquals(
+        { duration: 0.1,
+          selfTime: 0.1,
+          args: { 'arg1': 9.42 }
+        },
+        t.rows[2]);
+  });
+
+  test('analyzeSelectionTotalWithOneNumberOneTextArg', function() {
+    var selection = createSelectionWithOneNumberOneTextArg();
+
+    var sliceView = document.createElement('tv-c-multi-slice-sub-view');
+    var results = new StubAnalysisResults();
+    sliceView.analyzeMultipleSlices_(results, selection, 'Slices');
+    assertEquals(2, results.tables.length);
+
+    var t = results.tables[1];
+
+    assertObjectEquals(
+        { duration: 0.1,
+          selfTime: 0.1,
+          args: { 'arg1': 9.42 }
+        },
+        t.rows[2]);
+  });
+
+  test('analyzeSelectionTotalWithTwoNumberArgs', function() {
+    var selection = createSelectionWithTwoNumberArgs();
+
+    var sliceView = document.createElement('tv-c-multi-slice-sub-view');
+    var results = new StubAnalysisResults();
+    sliceView.analyzeMultipleSlices_(results, selection, 'Slices');
+    assertEquals(2, results.tables.length);
+
+    var t = results.tables[1];
+
+    assertObjectEquals(
+        { duration: 0.1,
+          selfTime: 0.1,
+          args: { 'arg1': 9.42, 'arg2': 300.0 }
+        },
+        t.rows[2]);
+  });
+
+  test('analyzeSelectionTotalWithMismatchedArgs', function() {
+    var selection = createSelectionWithMismatchedArgs();
+
+    var sliceView = document.createElement('tv-c-multi-slice-sub-view');
+    var results = new StubAnalysisResults();
+    sliceView.analyzeMultipleSlices_(results, selection, 'Slices');
+    assertEquals(2, results.tables.length);
+
+    var t = results.tables[1];
+
+    assertObjectEquals(
+        { duration: 0.4,
+          selfTime: 0.4,
+          args: { 'arg1': 10.42, 'arg2': 350.0 }
+        },
+        t.rows[5]);
   });
 });
 </script>


### PR DESCRIPTION
Show totals for duration, selftime, numeric arguments, and cpu
durations at the bottom of of the analysis view.
