### PR TITLE
Custom filename entry

### DIFF
--- a/trace_viewer/extras/about_tracing/profiling_view.html
+++ b/trace_viewer/extras/about_tracing/profiling_view.html
@@ -402,6 +402,33 @@ tv.exportTo('tv.e.about_tracing', function() {
       this.uploadOverlay_ = null;
     },
 
+    requestFilename_: function() {
+
+      // unsafe filename patterns:
+      var illegalRe = /[\/\?<>\\:\*\|":]/g;
+      var controlRe = /[\x00-\x1f\x80-\x9f]/g;
+      var reservedRe = /^\.+$/;
+
+      var defaultName = this.activeTrace_.filename;
+      var custom = prompt('Filename? (.json appended) Or leave blank:');
+      var filename;
+
+      if (custom) {
+        filename = defaultName.replace(/\.json$/, ' ' + custom) + '.json';
+      }
+      else {
+        var date = new Date();
+        var dateText = ' ' + date.toDateString() +
+                       ' ' + date.toLocaleTimeString();
+        filename = defaultName.replace(/\.json$/, dateText + '.json');
+      }
+
+      return filename
+              .replace(illegalRe, '.')
+              .replace(controlRe, '•')
+              .replace(reservedRe, '');
+    },
+
     onSaveClicked_: function() {
       // Create a blob URL from the binary array.
       var blob = new Blob([this.activeTrace_.data],
@@ -411,7 +438,7 @@ tv.exportTo('tv.e.about_tracing', function() {
       // Create a link and click on it. BEST API EVAR!
       var link = document.createElementNS('http://www.w3.org/1999/xhtml', 'a');
       link.href = blobUrl;
-      link.download = this.activeTrace_.filename;
+      link.download = this.requestFilename_();
       link.click();
     },
 

--- a/trace_viewer/extras/about_tracing/profiling_view.html
+++ b/trace_viewer/extras/about_tracing/profiling_view.html
@@ -417,8 +417,7 @@ tv.exportTo('tv.e.about_tracing', function() {
 
       if (custom) {
         filename = defaultName.replace(/\.json$/, ' ' + custom) + '.json';
-      }
-      else {
+      } else {
         var date = new Date();
         var dateText = ' ' + date.toDateString() +
                        ' ' + date.toLocaleTimeString();

--- a/trace_viewer/extras/about_tracing/profiling_view.html
+++ b/trace_viewer/extras/about_tracing/profiling_view.html
@@ -409,9 +409,11 @@ tv.exportTo('tv.e.about_tracing', function() {
       var controlRe = /[\x00-\x1f\x80-\x9f]/g;
       var reservedRe = /^\.+$/;
 
+      var filename;
       var defaultName = this.activeTrace_.filename;
       var custom = prompt('Filename? (.json appended) Or leave blank:');
-      var filename;
+      if (custom === null)
+        return false;
 
       if (custom) {
         filename = defaultName.replace(/\.json$/, ' ' + custom) + '.json';
@@ -439,7 +441,8 @@ tv.exportTo('tv.e.about_tracing', function() {
       var link = document.createElementNS('http://www.w3.org/1999/xhtml', 'a');
       link.href = blobUrl;
       link.download = this.requestFilename_();
-      link.click();
+      if (link.download)
+        link.click();
     },
 
     onUploadClicked_: function() {


### PR DESCRIPTION
#### Hey there tracing user! 
***Are you tired of the same old `trace (2).json` ?***
![image](https://cloud.githubusercontent.com/assets/39191/6400922/3545b304-bdb1-11e4-99ff-adde21e1d7cb.png)


***Wouldn't you like more meaningful names?***
![image](https://cloud.githubusercontent.com/assets/39191/6400936/5bf94b14-bdb1-11e4-9b2d-1f275cb74717.png)

***I've got just the patch for you!***

<hr>

I took a shot at more meaningful filenames. 

![image](https://cloud.githubusercontent.com/assets/39191/6400975/aa281252-bdb1-11e4-8da5-8b000061b00d.png)

We use a lovely blocking `prompt()` call to ask for a more meaningful name. If you ignore it and hit enter, you'll get a decent looking timestamp. And if you type, well… you'll get something better looking.

<hr>

I explored two options aside from the `prompt()` approach.

## auto-magical relevant name
I tried to pull a more meaningful name out of the process thread `userFriendlyName`s but it seems unreliable at the moment. 

## happy names
Gfycat uses unique word combinations for their urls, like http://gfycat.com/MagnificentHighCapybara and https://gfycat.com/TameRepentantAfricanbushviper  [[sources](http://www.reddit.com/r/gfycat/comments/2bkl5j/gfycat_url_generator/)]. We could do something similar.

In the end settled on prompt figuring it's the benefits of no more `trace (2).json` outweigh the costs of `prompt()`. 

What does everyone think?