### PR TITLE
Remove minimum flow arrow width.

### DIFF
--- a/trace_viewer/core/tracks/trace_model_track.html
+++ b/trace_viewer/core/tracks/trace_model_track.html
@@ -281,18 +281,10 @@ tv.exportTo('tv.c.tracks', function() {
       var events =
           this.model_.flowIntervalTree.findIntersection(viewLWorld, viewRWorld);
 
-      var minWidth = 2 * pixWidth;
       var canvasBounds = ctx.canvas.getBoundingClientRect();
-
       for (var i = 0; i < events.length; ++i) {
         var startEvent = events[i][0];
         var endEvent = events[i][1];
-
-        // Skip lines that will be, essentially, vertical.
-        var distance = endEvent.start - startEvent.start;
-        if (distance <= minWidth)
-          continue;
-
         this.drawFlowArrowBetween_(
             ctx, startEvent, endEvent, canvasBounds, pixWidth);
       }


### PR DESCRIPTION
We currently skip drawing flow lines if they are less then 2*pixWidth.
This was to stop vertical lines from being drawn. This turns out to
be more annoying for users as flow lines pop in and out dependant
on zoom level.

Drop the minimum and allow vertical flow lines.

Issue #788