### PR TITLE
Fix #814: add 'use strict' to time_span.html

### DIFF
--- a/trace_viewer/core/analysis/time_span.html
+++ b/trace_viewer/core/analysis/time_span.html
@@ -25,6 +25,8 @@ found in the LICENSE file.
     </span>
   </template>
   <script>
+  'use strict';
+
   Polymer({
     ready: function() {
       this.duration_ = undefined;


### PR DESCRIPTION
This patch fixes #814 simply by adding <tt>'use strict'</tt> to time_span.html.