### PR TITLE
Allow category value to be searched in filter controller

### DIFF
--- a/trace_viewer/core/filter.html
+++ b/trace_viewer/core/filter.html
@@ -60,6 +60,25 @@ tv.exportTo('tv.c', function() {
     }
   };
 
+  function TitleOrCategoryFilter(text) {
+    Filter.call(this);
+    this.text_ = text;
+
+    if (!text.length)
+      throw new Error('Filter text is empty');
+  }
+  TitleOrCategoryFilter.prototype = {
+    __proto__: Filter.prototype,
+
+    matchSlice: function(slice) {
+      if (slice.title === undefined && slice.category === undefined)
+        return false;
+      return slice.title.toLowerCase().indexOf(
+                this.text_.toLowerCase()) !== -1 ||
+             slice.category.indexOf(this.text_) !== -1;
+    }
+  };
+
   /**
    * @constructor A filter that matches objects with the exact given title.
    */
@@ -80,7 +99,8 @@ tv.exportTo('tv.c', function() {
 
   return {
     TitleFilter: TitleFilter,
-    ExactTitleFilter: ExactTitleFilter
+    ExactTitleFilter: ExactTitleFilter,
+    TitleOrCategoryFilter: TitleOrCategoryFilter
   };
 });
 </script>

--- a/trace_viewer/core/filter_test.html
+++ b/trace_viewer/core/filter_test.html
@@ -15,6 +15,7 @@ found in the LICENSE file.
 tv.b.unittest.testSuite(function() {
   var TitleFilter = tv.c.TitleFilter;
   var ExactTitleFilter = tv.c.ExactTitleFilter;
+  var TitleOrCategoryFilter = tv.c.TitleOrCategoryFilter;
 
   test('titleFilter', function() {
     assertThrows(function() {
@@ -57,6 +58,30 @@ tv.b.unittest.testSuite(function() {
     assertFalse(new ExactTitleFilter('Abc').matchSlice(s1));
     assertFalse(new ExactTitleFilter('bc').matchSlice(s1));
     assertFalse(new ExactTitleFilter('a').matchSlice(s1));
+  });
+
+  test('titleOrCategoryFilter', function() {
+    assertThrows(function() {
+      new TitleOrCategoryFilter();
+    });
+    assertThrows(function() {
+      new TitleOrCategoryFilter('');
+    });
+
+    var s0 = tv.c.test_utils.newSliceCategory('cat', 'a', 1, 3);
+    assertTrue(new TitleOrCategoryFilter('a').matchSlice(s0));
+    assertTrue(new TitleOrCategoryFilter('cat').matchSlice(s0));
+    assertTrue(new TitleOrCategoryFilter('at').matchSlice(s0));
+    assertFalse(new TitleOrCategoryFilter('b').matchSlice(s0));
+    assertFalse(new TitleOrCategoryFilter('X').matchSlice(s0));
+
+    var s1 = tv.c.test_utils.newSliceCategory('cat', 'abc', 1, 3);
+    assertTrue(new TitleOrCategoryFilter('abc').matchSlice(s1));
+    assertTrue(new TitleOrCategoryFilter('Abc').matchSlice(s1));
+    assertTrue(new TitleOrCategoryFilter('cat').matchSlice(s1));
+    assertFalse(new TitleOrCategoryFilter('Cat').matchSlice(s1));
+    assertFalse(new TitleOrCategoryFilter('cat1').matchSlice(s1));
+    assertFalse(new TitleOrCategoryFilter('X').matchSlice(s1));
   });
 });
 </script>

--- a/trace_viewer/core/find_controller.html
+++ b/trace_viewer/core/find_controller.html
@@ -64,7 +64,7 @@ tv.exportTo('tv.c', function() {
       this.currentHitIndex_ = -1;
 
       if (this.timeline_ && this.filterText.length) {
-        var filter = new tv.c.TitleFilter(this.filterText);
+        var filter = new tv.c.TitleOrCategoryFilter(this.filterText);
         var filterHits = new tv.c.Selection();
         var filterTask =
             this.timeline.addAllObjectsMatchingFilterToSelectionAsTask(


### PR DESCRIPTION
Allow category value to be searched in filter controller

Search box doesn't allow searching for category names. User should be
able to search in the trace even by category names.
Add a new search filter which searches inputted text against either of
function title or category name under which function is registered.

BUG=#539

TEST=Updated filter_test.html