### PR TITLE
Add classes for internal memory representation.

### DIFF
--- a/trace_viewer/core/trace_model/allocated_memory_tree.html
+++ b/trace_viewer/core/trace_model/allocated_memory_tree.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 The Chromium Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<link rel="import" href="/core/trace_model/memory_tree.html">
+
+<script>
+'use strict';
+
+/**
+ * @fileoverview Provides classes for representing the hierarchy of allocated
+ *     memory.
+ */
+tv.exportTo('tv.c.trace_model', function() {
+
+  /**
+   * @constructor
+   * @extends {MemoryTreeNode}
+   */
+  var AllocatedMemoryTreeNode = function(allocatorDump, opt_parent) {
+    tv.c.trace_model.MemoryTreeNode.call(
+        this,
+        allocatorDump.name,
+        AllocatedMemoryTreeNode.extractComponentName(allocatorDump),
+        opt_parent);
+    this.allocatorDump = allocatorDump;
+
+    if (allocatorDump.children) {
+      this.children = [];
+      for (var i = 0; i < allocatorDump.children.length; i++) {
+        this.children.push(new AllocatedMemoryTreeNode(
+            allocatorDump.children[i], this));
+      }
+    }
+  };
+
+  AllocatedMemoryTreeNode.prototype = {
+    __proto__: tv.c.trace_model.MemoryTreeNode.prototype
+  };
+
+  /**
+   * Extracts component name from the full name of an allocator dump. For
+   * example, if the full name of a dump is 'oilpan/general' and the name of its
+   * parent is 'oilpan', then the component name of the dump is 'general'.
+   */
+  AllocatedMemoryTreeNode.extractComponentName = function(allocatorDump) {
+    if (allocatorDump.name.indexOf(allocatorDump.parent + '/') === 0) {
+      return allocatorDump.name.substring(allocatorDump.parent.length + 1);
+    } else {
+      return allocatorDump.name;
+    }
+  };
+
+  /**
+   * @constructor
+   * @extends {NumericMemoryTreeFieldSpecifier}
+   */
+  var AllocatedMemoryTreeFieldSpecifier = function(userFriendlyName,
+      allocatorDumpKey, opt_numberFormatter) {
+    tv.c.trace_model.NumericMemoryTreeFieldSpecifier.call(
+        this,
+        userFriendlyName.toLowerCase().replace(' ', '_'),
+        userFriendlyName,
+        allocatorDumpKey,
+        opt_numberFormatter);
+    this.allocatorDumpKey_ = allocatorDumpKey;
+  };
+
+  AllocatedMemoryTreeFieldSpecifier.prototype = {
+    __proto__: tv.c.trace_model.NumericMemoryTreeFieldSpecifier.prototype,
+
+    getNodeNumber: function(node) {
+      return parseInt(node.allocatorDump[this.allocatorDumpKey_], 16);
+    },
+
+    shouldSumChildren: function(node) {
+      // Allow the values in non-leaf nodes to differ from sums of their
+      // children's values.
+      return !!node.children &&
+          node.allocatorDump[this.allocatorDumpKey_] === undefined;
+    }
+  };
+
+  /**
+   * A tree representing a hierarchy of allocated memory (for a single
+   * allocator, e.g. Oilpan) together with its fields.
+   * @constructor
+   * @extends {MemoryTree}
+   */
+  var AllocatedMemoryTree = function(allocatorName) {
+    tv.c.trace_model.MemoryTree.call(this);
+    this.allocatorName = allocatorName;
+    this.fields = AllocatedMemoryTree.FIELD_SPECIFIERS;
+    this.allocatorDump_ = undefined;
+  };
+
+  AllocatedMemoryTree.prototype = {
+    __proto__: tv.c.trace_model.MemoryTree.prototype,
+
+    get allocatorDump() {
+      return this.allocatorDump_;
+    },
+
+    set allocatorDump(allocatorDump) {
+      this.allocatorDump_ = allocatorDump;
+      this.root = new AllocatedMemoryTreeNode(allocatorDump);
+    }
+  };
+
+  /**
+   * Parse a list of flattened allocator dumps (coming from a ProcessMemoryDump
+   * trace events) into a list of AllocatedMemoryTree objects.
+   */
+  AllocatedMemoryTree.parseTrees = function(flattenedAllocatorDumps) {
+    // Ensure that the roots as well as the descendant dumps are sorted.
+    var names = Object.keys(flattenedAllocatorDumps);
+    names.sort();
+
+    // Link parent dumps to their children.
+    for (var i = 0; i < names.length; i++) {
+      var name = names[i];
+      var dump = flattenedAllocatorDumps[name];
+      dump.name = name;
+
+      if (!dump.parent) {
+        // A root node.
+        continue;
+      }
+
+      var parentDump = flattenedAllocatorDumps[dump.parent];
+      if (!parentDump.children) {
+        parentDump.children = [];
+      }
+      parentDump.children.push(dump);
+    }
+
+    // Build the trees from roots.
+    var trees = [];
+    for (var i = 0; i < names.length; i++) {
+      var name = names[i];
+      var dump = flattenedAllocatorDumps[name];
+
+      if (dump.parent) {
+        // A non-root node.
+        continue;
+      }
+
+      var tree = new AllocatedMemoryTree(name);
+      tree.allocatorDump = dump;
+      trees.push(tree);
+    }
+
+    return trees;
+  };
+
+  AllocatedMemoryTree.FIELD_SPECIFIERS = [
+    new AllocatedMemoryTreeFieldSpecifier('Physical size', 'physical_size',
+        tv.c.trace_model.NumericMemoryTreeFieldSpecifier.SIZE_FORMATTER),
+    new AllocatedMemoryTreeFieldSpecifier('Allocated objects count',
+        'allocated_objects_count'),
+    new AllocatedMemoryTreeFieldSpecifier('Allocated objects size',
+        'allocated_objects_size',
+        tv.c.trace_model.NumericMemoryTreeFieldSpecifier.SIZE_FORMATTER)
+  ];
+
+  return {
+    AllocatedMemoryTreeNode: AllocatedMemoryTreeNode,
+    AllocatedMemoryTreeFieldSpecifier: AllocatedMemoryTreeFieldSpecifier,
+    AllocatedMemoryTree: AllocatedMemoryTree
+  };
+});
+</script>

--- a/trace_viewer/core/trace_model/allocated_memory_tree_test.html
+++ b/trace_viewer/core/trace_model/allocated_memory_tree_test.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 The Chromium Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<link rel="import" href="/core/test_utils.html">
+<link rel="import" href="/core/trace_model/allocated_memory_tree.html">
+
+<script>
+'use strict';
+
+tv.b.unittest.testSuite(function() {
+  var AllocatedMemoryTree = tv.c.trace_model.AllocatedMemoryTree;
+  var AllocatedMemoryTreeNode = tv.c.trace_model.AllocatedMemoryTreeNode;
+
+  test('checkExtractComponentName', function() {
+    var f = AllocatedMemoryTreeNode.extractComponentName;
+
+    // Don't extract
+    assertEquals(f({name: 'v8', parent: ''}), 'v8');
+    assertEquals(f({name: 'gen', parent: 'v8'}), 'gen');
+    assertEquals(f({name: 'v7/gen', parent: 'v8'}), 'v7/gen');
+
+    // Extract.
+    assertEquals(f({name: 'v8/gen', parent: 'v8'}), 'gen');
+    assertEquals(f({name: 'v8/gen/b1', parent: 'v8/gen'}), 'b1');
+    assertEquals(f({name: 'v8/gen/b1/e_priv', parent: 'v8/gen/b1'}), 'e_priv');
+  });
+
+  test('checkParseTrees_noTrees', function() {
+    var trees = AllocatedMemoryTree.parseTrees({});
+    assertEquals(trees.length, 0);
+  });
+
+  test('checkParseTrees_singletonTree', function() {
+    var trees = AllocatedMemoryTree.parseTrees({
+      'oilpan': {
+        'parent': '',
+        'physical_size': 'aaa',
+        'allocated_objects_count': '10',
+        'allocated_objects_size': '80'
+      }
+    });
+
+    assertEquals(trees.length, 1);
+
+    assertEquals(trees[0].allocatorName, 'oilpan');
+    assertEquals(trees[0].fields[0].toString(trees[0].root), '2.7 KiB');
+    assertEquals(trees[0].fields[1].toString(trees[0].root), '16');
+    assertEquals(trees[0].fields[2].toString(trees[0].root), '128.0 B');
+  });
+
+  test('checkParseTrees_deepTree', function() {
+    var trees = AllocatedMemoryTree.parseTrees({
+      'oilpan/general': {
+        'parent': 'oilpan'
+      },
+      'oilpan/general/bucket1': {
+        'parent': 'oilpan/general',
+        'physical_size': '5',
+        'allocated_objects_count': '10',
+        'allocated_objects_size': '80'
+      },
+      'oilpan/general/bucket2': {
+        'parent': 'oilpan/general',
+        'physical_size': '5',
+        'allocated_objects_count': '12',
+        'allocated_objects_size': '50'
+      },
+      'oilpan': {
+        'parent': ''
+      },
+      'oilpan/hashtables': {
+        'parent': 'oilpan',
+        'physical_size': 'f',
+        'allocated_objects_count': '5',
+        'allocated_objects_size': '9'
+      }
+    });
+
+    assertEquals(trees.length, 1);
+    assertEquals(trees[0].allocatorName, 'oilpan');
+    var root = trees[0].root;
+
+    assertEquals(root.userFriendlyName, 'oilpan');
+    assertEquals(root.children[0].userFriendlyName, 'general');
+    assertEquals(root.children[0].children[0].userFriendlyName, 'bucket1');
+    assertEquals(root.children[0].children[1].userFriendlyName, 'bucket2');
+    assertEquals(root.children[1].userFriendlyName, 'hashtables');
+
+    assertEquals(root.children.length, 2);
+    assertEquals(root.children[0].children.length, 2);
+    assertUndefined(root.children[0].children[0].children);
+    assertUndefined(root.children[0].children[1].children);
+    assertUndefined(root.children[1].children);
+
+    assertEquals(trees[0].fields[0].toString(trees[0].root), '25.0 B');
+    assertEquals(trees[0].fields[1].toString(trees[0].root), '39');
+    assertEquals(trees[0].fields[2].toString(trees[0].root), '217.0 B');
+  });
+
+  test('checkParseTrees_multipleTrees', function() {
+    var trees = AllocatedMemoryTree.parseTrees({
+      'skia/layers': {
+        'parent': 'skia'
+      },
+      'oilpan': {
+        'parent': ''
+      },
+      'v8': {
+        'parent': ''
+      },
+      'skia': {
+        'parent': ''
+      }
+    });
+
+    assertEquals(trees.length, 3);
+
+    assertEquals(trees[0].allocatorName, 'oilpan');
+    assertEquals(trees[0].root.userFriendlyName, 'oilpan');
+    assertUndefined(trees[0].root.children);
+
+    assertEquals(trees[1].allocatorName, 'skia');
+    assertEquals(trees[1].root.userFriendlyName, 'skia');
+    assertEquals(trees[1].root.children.length, 1);
+    assertEquals(trees[1].root.children[0].userFriendlyName, 'layers');
+    assertUndefined(trees[1].root.children[0].children);
+
+    assertEquals(trees[2].allocatorName, 'v8');
+    assertEquals(trees[2].root.userFriendlyName, 'v8');
+    assertUndefined(trees[2].root.children);
+  });
+
+  test('checkParseTrees_differentParentValue', function() {
+    var trees = AllocatedMemoryTree.parseTrees({
+      'v8': {
+        'parent': '',
+        'physical_size': '20',
+        'allocated_objects_count': '2'
+      },
+      'v8/bucket1': {
+        'parent': 'v8',
+        'physical_size': '5',
+        'allocated_objects_count': '1',
+        'allocated_objects_size': '3'
+      },
+      'v8/bucket2': {
+        'parent': 'v8',
+        'physical_size': '5',
+        'allocated_objects_count': '2',
+        'allocated_objects_size': '4'
+      }
+    });
+
+    assertEquals(trees.length, 1);
+    assertEquals(trees[0].allocatorName, 'v8');
+    var root = trees[0].root;
+
+    assertEquals(root.children.length, 2);
+
+    // Parent value greater than the sum.
+    assertEquals(trees[0].fields[0].toString(root), '32.0 B');
+    assertEquals(trees[0].fields[0].toString(root.children[0]), '5.0 B');
+    assertEquals(trees[0].fields[0].toString(root.children[1]), '5.0 B');
+
+    // Parent value less than the sum.
+    assertEquals(trees[0].fields[1].toString(root), '2');
+    assertEquals(trees[0].fields[1].toString(root.children[0]), '1');
+    assertEquals(trees[0].fields[1].toString(root.children[1]), '2');
+
+    // Parent value equal to the sum (default behavior).
+    assertEquals(trees[0].fields[2].toString(root), '7.0 B');
+    assertEquals(trees[0].fields[2].toString(root.children[0]), '3.0 B');
+    assertEquals(trees[0].fields[2].toString(root.children[1]), '4.0 B');
+  });
+});
+</script>

--- a/trace_viewer/core/trace_model/memory_tree.html
+++ b/trace_viewer/core/trace_model/memory_tree.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 The Chromium Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<link rel="import" href="/base/base.html">
+
+<script>
+'use strict';
+
+/**
+ * @fileoverview Provides classes for representing memory hierarchy.
+ */
+tv.exportTo('tv.c.trace_model', function() {
+
+  /**
+   * @constructor
+   */
+  var MemoryTreeNode = function(name, userFriendlyName, opt_parent) {
+    this.name = name;
+    this.userFriendlyName = userFriendlyName;
+    this.parent = opt_parent || undefined;
+    this.children = undefined;
+    this.fieldCache_ = undefined;
+  };
+
+  MemoryTreeNode.prototype = {
+    invalidateFieldCache: function() {
+      for (var node = this; node; node = node.parent) {
+        node.fieldCache_ = undefined;
+      }
+    },
+
+    get fieldCache() {
+      if (!this.fieldCache_) {
+        this.fieldCache_ = {};
+      }
+      return this.fieldCache_;
+    }
+  };
+
+  /**
+   * An object which specifies how a certain field (e.g. 'Physical size') of all
+   * nodes in a memory tree is calculated and displayed.
+   * @constructor
+   */
+  var MemoryTreeFieldSpecifier = function(name, userFriendlyName) {
+    this.name = name;
+    this.userFriendlyName = userFriendlyName;
+  };
+
+  MemoryTreeFieldSpecifier.prototype = {
+    toString: function(node) {
+      throw new Error('toString() method not implemented');
+    }
+  };
+
+  /**
+   * A field specifier for numeric fields with support for caching the value of
+   * a field in a node and recursively calculating its value as a sum of the
+   * values of the field in the node's children.
+   * @constructor
+   * @extends {MemoryTreeFieldSpecifier}
+   */
+  var NumericMemoryTreeFieldSpecifier = function(name, userFriendlyName,
+      cacheKey, opt_numberFormatter) {
+    MemoryTreeFieldSpecifier.call(this, name, userFriendlyName);
+    this.cacheKey_ = cacheKey;
+    this.numberFormatter_ = opt_numberFormatter || undefined;
+  };
+
+  NumericMemoryTreeFieldSpecifier.prototype = {
+    __proto__: MemoryTreeFieldSpecifier.prototype,
+
+    toString: function(node) {
+      var numericValue = this.toNumber(node);
+      return this.numberFormatter_ ?
+          this.numberFormatter_(numericValue) : numericValue.toString();
+    },
+
+    toNumber: function(node) {
+      if (!(this.cacheKey_ in node.fieldCache)) {
+        var cachedValue;
+        if (this.shouldSumChildren(node)) {
+          cachedValue = 0;
+          for (var i = 0; i < node.children.length; i++) {
+            cachedValue += this.toNumber(node.children[i]);
+          }
+        } else {
+          cachedValue = this.getNodeNumber(node);
+        }
+        node.fieldCache[this.cacheKey_] = cachedValue;
+      }
+      return node.fieldCache[this.cacheKey_];
+    },
+
+    /**
+     * @return {boolean} True if the value of this field for the given node
+     *     should be calculated recursively as the sum of the values of this
+     *     field for the node's children.
+     */
+    shouldSumChildren: function(node) {
+      return !!node.children;
+    },
+
+    /**
+     * @return {number} Get the value of this field for the given node.
+     */
+    getNodeNumber: function(node) {
+      throw new Error('getNodeValue() method not implemented');
+    }
+  };
+
+  NumericMemoryTreeFieldSpecifier.SIZE_UNITS = ['Ki', 'Mi', 'Gi', 'Ti'];
+
+  /**
+   * Formatter for memory size (e.g. 4300 -> '4.2 KiB').
+   */
+  NumericMemoryTreeFieldSpecifier.SIZE_FORMATTER = function(size) {
+    var unit = '';
+    for (var i = 0; i < NumericMemoryTreeFieldSpecifier.SIZE_UNITS.length;
+         i++) {
+      if (size < 1024)
+        break;
+      size /= 1024;
+      unit = NumericMemoryTreeFieldSpecifier.SIZE_UNITS[i];
+    }
+    return size.toFixed(1) + ' ' + unit + 'B';
+  };
+
+  /**
+   * A tree representing memory hierarchy together with its fields.
+   * @constructor
+   */
+  function MemoryTree() {
+    this.fields_ = [];
+    this.root_ = undefined;
+    this.nodes_ = undefined;
+  };
+
+  MemoryTree.prototype = {
+    __proto__: Object.prototype,
+
+    get fields() {
+      return this.fields_;
+    },
+
+    set fields(fields) {
+      this.fields_ = fields;
+    },
+
+    get root() {
+      return this.root_;
+    },
+
+    set root(root) {
+      this.root_ = root;
+      this.nodes_ = undefined;
+
+      if (root) {
+        this.nodes_ = {};
+        this.storeNodeNames_(root);
+      }
+    },
+
+    get nodes() {
+      return this.nodes_;
+    },
+
+    storeNodeNames_: function(node) {
+      this.nodes_[node.name] = node;
+
+      if (!node.children) {
+        return;
+      }
+
+      for (var i = 0; i < node.children.length; i++) {
+        this.storeNodeNames_(node.children[i]);
+      }
+    }
+  };
+
+  return {
+    MemoryTreeNode: MemoryTreeNode,
+    MemoryTreeFieldSpecifier: MemoryTreeFieldSpecifier,
+    NumericMemoryTreeFieldSpecifier: NumericMemoryTreeFieldSpecifier,
+    MemoryTree: MemoryTree
+  };
+});
+
+</script>

--- a/trace_viewer/core/trace_model/memory_tree_test.html
+++ b/trace_viewer/core/trace_model/memory_tree_test.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 The Chromium Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<link rel="import" href="/core/test_utils.html">
+<link rel="import" href="/core/trace_model/memory_tree.html">
+
+<script>
+'use strict';
+
+tv.b.unittest.testSuite(function() {
+  var MemoryTree = tv.c.trace_model.MemoryTree;
+  var MemoryTreeNode = tv.c.trace_model.MemoryTreeNode;
+  var MemoryTreeFieldSpecifier = tv.c.trace_model.MemoryTreeFieldSpecifier;
+  var NumericMemoryTreeFieldSpecifier =
+      tv.c.trace_model.NumericMemoryTreeFieldSpecifier;
+
+  var createMemoryTree = function() {
+    // Create 3 fields:
+    // Textual (non-numeric) field.
+    var textField = new MemoryTreeFieldSpecifier('txt_field', 'Text Field');
+    textField.toString = function(node) { return node.text; };
+
+    // Numeric field with the default formatter.
+    var numericField = new NumericMemoryTreeFieldSpecifier('num_field',
+        'Numeric Field', 'num_field');
+    numericField.getNodeNumber = function(node) { return node.value; };
+
+    // Numeric field with the size formatter which allows the value of
+    // a non-leaf node to differ from the sum of its children's values.
+    var sizeField = new NumericMemoryTreeFieldSpecifier('size_field',
+        'Physical Size', 'physical_size',
+        NumericMemoryTreeFieldSpecifier.SIZE_FORMATTER);
+    sizeField.getNodeNumber = numericField.getNodeNumber;
+    sizeField.shouldSumChildren = function(node) {
+      return node.value === undefined;
+    };
+
+    var fields = [textField, numericField, sizeField];
+
+    // Create a root node with two children.
+    var root = new MemoryTreeNode('root', 'Total');
+    root.text = 'all';
+    root.value = 20;
+    var leftChild = new MemoryTreeNode('left_child', 'Private', root);
+    leftChild.text = 'secret';
+    leftChild.value = 7;
+    var rightChild = new MemoryTreeNode('right_child', 'Shared', root);
+    rightChild.text = 'public';
+    rightChild.value = 8;
+    root.children = [leftChild, rightChild];
+
+    var tree = new MemoryTree();
+    tree.fields = fields;
+    tree.root = root;
+
+    return tree;
+  };
+
+  test('checkSizeFormatter', function() {
+    var formatter = NumericMemoryTreeFieldSpecifier.SIZE_FORMATTER;
+
+    assertEquals(formatter(0), '0.0 B');
+    assertEquals(formatter(1), '1.0 B');
+    assertEquals(formatter(1023), '1023.0 B');
+    assertEquals(formatter(1024), '1.0 KiB');
+    assertEquals(formatter(1536), '1.5 KiB');
+    assertEquals(formatter(1023898), '999.9 KiB');
+    assertEquals(formatter(1024 * 1023), '1023.0 KiB');
+    assertEquals(formatter(1024 * 1024), '1.0 MiB');
+    assertEquals(formatter(424.2 * 1024 * 1024), '424.2 MiB');
+    assertEquals(formatter(5 * 1024 * 1024 * 1024), '5.0 GiB');
+  });
+
+  test('checkTreeLayout', function() {
+    var tree = createMemoryTree();
+
+    // Check that the tree contains the correct nodes.
+    assertEquals(tree.root.userFriendlyName, 'Total');
+    assertEquals(tree.root.children[0].userFriendlyName, 'Private');
+    assertEquals(tree.root.children[1].userFriendlyName, 'Shared');
+
+    // Check that there are no other nodes in the tree.
+    assertEquals(tree.root.children.length, 2);
+    assertUndefined(tree.root.children[0].children);
+    assertUndefined(tree.root.children[1].children);
+
+    // Check that children have the corrent link to their parent.
+    assertUndefined(tree.root.parent);
+    assertEquals(tree.root.children[0].parent, tree.root);
+    assertEquals(tree.root.children[1].parent, tree.root);
+
+    // Check that all nodes are stored appropriately.
+    assertEquals(Object.keys(tree.nodes).length, 3);
+    assertEquals(tree.nodes['root'], tree.root);
+    assertEquals(tree.nodes['left_child'], tree.root.children[0]);
+    assertEquals(tree.nodes['right_child'], tree.root.children[1]);
+  });
+
+  test('checkTextFieldValues', function() {
+    var tree = createMemoryTree();
+    var textField = tree.fields[0];
+
+    assertEquals(textField.toString(tree.root), 'all');
+    assertEquals(textField.toString(tree.root.children[0]), 'secret');
+    assertEquals(textField.toString(tree.root.children[1]), 'public');
+
+    // Non-numeric fields do not provide a toNumber() method.
+    assertUndefined(textField.toNumber);
+  });
+
+  test('checkNumericFieldValues', function() {
+    var tree = createMemoryTree();
+    var numericField = tree.fields[1];
+
+    assertEquals(numericField.toNumber(tree.root), 15);
+    assertEquals(numericField.toNumber(tree.root.children[0]), 7);
+    assertEquals(numericField.toNumber(tree.root.children[1]), 8);
+
+    // The default number formatter simply converts a number to its string
+    // representation.
+    assertEquals(numericField.toString(tree.root), '15');
+    assertEquals(numericField.toString(tree.root.children[0]), '7');
+    assertEquals(numericField.toString(tree.root.children[1]), '8');
+  });
+
+  test('checkSizeFieldValues', function() {
+    var tree = createMemoryTree();
+    var sizeField = tree.fields[2];
+
+    assertEquals(sizeField.toNumber(tree.root), 20);
+    assertEquals(sizeField.toNumber(tree.root.children[0]), 7);
+    assertEquals(sizeField.toNumber(tree.root.children[1]), 8);
+
+    // The custom number formatter converts the number to memory size.
+    assertEquals(sizeField.toString(tree.root), '20.0 B');
+    assertEquals(sizeField.toString(tree.root.children[0]), '7.0 B');
+    assertEquals(sizeField.toString(tree.root.children[1]), '8.0 B');
+  });
+
+  test('checkNumericFieldCaching', function() {
+    var tree = createMemoryTree();
+    var numericField = tree.fields[1];
+
+    tree.root.children[0].value = 6;
+
+    // No caching has been performed yet so the value should be correct.
+    assertEquals(numericField.toNumber(tree.root), 14);
+
+    tree.root.children[0].value = 0;
+
+    // The value was cached upon retrieval, but the cache was not invalidated
+    // after the update.
+    assertEquals(numericField.toNumber(tree.root), 14);
+
+    tree.root.children[0].invalidateFieldCache();
+
+    // The value should be correct again after the invalidation.
+    assertEquals(numericField.toNumber(tree.root), 8);
+  });
+});
+</script>

--- a/trace_viewer/core/trace_model/used_memory_tree.html
+++ b/trace_viewer/core/trace_model/used_memory_tree.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 The Chromium Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<link rel="import" href="/core/trace_model/memory_tree.html">
+
+<script>
+'use strict';
+
+/**
+ * @fileoverview Provides classes for representing the hierarchy of used memory.
+ */
+tv.exportTo('tv.c.trace_model', function() {
+
+  /**
+   * @constructor
+   * @extends {MemoryTreeNode}
+   */
+  var UsedMemoryTreeNode = function(rule, opt_parent) {
+    tv.c.trace_model.MemoryTreeNode.call(this, rule.name, rule.userFriendlyName,
+        opt_parent);
+    this.rule = rule;
+
+    var subRules = rule.subRules;
+    if (!subRules) {
+      // Leaf node.
+      this.mmaps = [];
+      return;
+    }
+
+    this.children = [];
+    for (var i = 0; i < subRules.length; i++) {
+      this.children.push(new UsedMemoryTreeNode(subRules[i], this));
+    }
+  };
+
+  UsedMemoryTreeNode.prototype = {
+    __proto__: tv.c.trace_model.MemoryTreeNode.prototype,
+
+    addMmap: function(mmap) {
+      if (!this.children) {
+        // Leaf node.
+        this.mmaps.push(mmap);
+        this.invalidateFieldCache();
+        return;
+      }
+
+      // Find the right child that this mmap belongs to.
+      for (var i = 0; i < this.children.length; i++) {
+        var child = this.children[i];
+        if (child.matchesMmap_(mmap)) {
+          child.addMmap(mmap);
+          return;
+        }
+      }
+
+      // This should never happen because of the explicit 'Other' rules.
+      throw new Error('Unreachable');
+    },
+
+    matchesMmap_: function(mmap) {
+      var conditions = this.rule.conditions;
+
+      if (conditions.file) {
+        if (!conditions.file.test(mmap.mapped_file)) {
+          return false;
+        }
+      }
+
+      if (conditions.prot) {
+        var protectionFlagsString = UsedMemoryTreeNode.protectionFlagsToString(
+            mmap.protection_flags);
+        if (!conditions.prot.test(protectionFlagsString)) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+  };
+
+  UsedMemoryTreeNode.protectionFlagsToString = function(flags) {
+    return ((flags & 4) ? 'r' : '-') + ((flags & 2) ? 'w' : '-') +
+        ((flags & 1) ? 'x' : '-');
+  };
+
+  /**
+   * @constructor
+   * @extends {NumericMemoryTreeFieldSpecifier}
+   */
+  var UsedMemoryTreeFieldSpecifier = function(userFriendlyName, byteStatsKey) {
+    tv.c.trace_model.NumericMemoryTreeFieldSpecifier.call(
+        this,
+        userFriendlyName.toLowerCase().replace(' ', '_'),
+        userFriendlyName,
+        byteStatsKey,
+        tv.c.trace_model.NumericMemoryTreeFieldSpecifier.SIZE_FORMATTER);
+    this.byteStatsKey_ = byteStatsKey;
+  };
+
+  UsedMemoryTreeFieldSpecifier.prototype = {
+    __proto__: tv.c.trace_model.NumericMemoryTreeFieldSpecifier.prototype,
+
+    getNodeNumber: function(node) {
+      var sum = 0;
+      for (var i = 0; i < node.mmaps.length; i++) {
+        var mmap = node.mmaps[i];
+        sum += parseInt(mmap.byte_stats[this.byteStatsKey_], 16);
+      }
+      return sum;
+    }
+  };
+
+  /**
+   * A tree representing the hierarchy of used memory (derived from memory maps)
+   * together with its fields.
+   * @constructor
+   * @extends {MemoryTree}
+   */
+  function UsedMemoryTree() {
+    tv.c.trace_model.MemoryTree.call(this);
+    this.fields = UsedMemoryTree.FIELD_SPECIFIERS;
+    this.mmaps_ = undefined;
+  };
+
+  UsedMemoryTree.prototype = {
+    __proto__: tv.c.trace_model.MemoryTree.prototype,
+
+    get mmaps() {
+      return this.mmaps_;
+    },
+
+    set mmaps(mmaps) {
+      this.mmaps_ = mmaps;
+
+      this.root = new UsedMemoryTreeNode(UsedMemoryTree.CLASSIFICATION_RULES);
+      for (var i = 0; i < mmaps.length; i++) {
+        this.root.addMmap(mmaps[i]);
+      }
+    }
+  };
+
+  var finalizeRulesRecursively = function(rule) {
+    if (!rule.subRules) {
+      return;
+    }
+
+    // Add an 'Other' child that will match all mmaps.
+    rule.subRules.push({
+      'userFriendlyName': 'Other',
+      'conditions': {}
+    });
+
+    // Finalize all sub-rules.
+    for (var i = 0; i < rule.subRules.length; i++) {
+      var subRule = rule.subRules[i];
+      var subName = subRule.userFriendlyName.toLowerCase().replace(' ', '_');
+      subRule.name = rule.name + subName + '/';
+      finalizeRulesRecursively(subRule);
+    }
+  };
+
+  var finalizeRules = function(root) {
+    root.name = '/';
+    finalizeRulesRecursively(root);
+    return root;
+  };
+
+  /**
+   * Rules for classifying process memory maps.
+   */
+  UsedMemoryTree.CLASSIFICATION_RULES = finalizeRules({
+    'userFriendlyName': 'Total',
+    'conditions': {},
+    'subRules': [
+      {
+        'userFriendlyName': 'Anon',
+        'conditions': {
+          'file': /(^$)|(^\[)/
+        },
+        'subRules': [
+          {
+            'userFriendlyName': 'stack',
+            'conditions': {
+              'file': /\[stack/
+            }
+          },
+          {
+            'userFriendlyName': 'libc malloc',
+            'conditions': {
+              'file': /libc_malloc/
+            }
+          },
+          {
+            'userFriendlyName': 'JIT',
+            'conditions': {
+              'prot': /r.x/
+            }
+          }
+        ]
+      },
+      {
+        'userFriendlyName': 'Ashmem',
+        'conditions': {
+          'file': /^\/dev\/ashmem/
+        },
+        'subRules': [
+          {
+            'userFriendlyName': 'Dalvik',
+            'conditions': {
+              'file': /^\/dev\/ashmem\/dalvik/
+            },
+            'subRules': [
+              {
+                'userFriendlyName': 'Java Heap',
+                'conditions': {
+                  'file': /dalvik-heap/
+                }
+              },
+              {
+                'userFriendlyName': 'JIT',
+                'conditions': {
+                  'prot': /r.x/
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        'userFriendlyName': 'Libs',
+        'conditions': {
+          'file': /(\.so)|(\.apk)|(\.jar)/
+        },
+        'subRules': [
+          {
+            'userFriendlyName': 'Native',
+            'conditions': {
+              'file': /\.so/
+            }
+          },
+          {
+            'userFriendlyName': 'APKs',
+            'conditions': {
+              'file': /\.apk/
+            }
+          },
+          {
+            'userFriendlyName': 'JARs',
+            'conditions': {
+              'file': /\.jar/
+            }
+          }
+        ]
+      },
+      {
+        'userFriendlyName': 'Devices',
+        'conditions': {
+          'file': /^\/dev\//
+        },
+        'subRules': [
+          {
+            'userFriendlyName': 'GPU',
+            'conditions': {
+              'file': /(nv)|(mali)|(kgsl)/
+            }
+          }
+        ]
+      }
+    ]
+  });
+
+  UsedMemoryTree.FIELD_SPECIFIERS = [
+    new UsedMemoryTreeFieldSpecifier('RSS', 'rss'),
+    new UsedMemoryTreeFieldSpecifier('PSS', 'pss'),
+    new UsedMemoryTreeFieldSpecifier('Private memory', 'private'),
+    new UsedMemoryTreeFieldSpecifier('Shared memory', 'shared')
+  ];
+
+  return {
+    UsedMemoryTreeNode: UsedMemoryTreeNode,
+    UsedMemoryTreeFieldSpecifier: UsedMemoryTreeFieldSpecifier,
+    UsedMemoryTree: UsedMemoryTree
+  };
+});
+</script>

--- a/trace_viewer/core/trace_model/used_memory_tree_test.html
+++ b/trace_viewer/core/trace_model/used_memory_tree_test.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2015 The Chromium Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<link rel="import" href="/core/test_utils.html">
+<link rel="import" href="/core/trace_model/used_memory_tree.html">
+
+<script>
+'use strict';
+
+tv.b.unittest.testSuite(function() {
+  var UsedMemoryTree = tv.c.trace_model.UsedMemoryTree;
+  var UsedMemoryTreeNode = tv.c.trace_model.UsedMemoryTreeNode;
+
+  test('checkProtectionFlagsToString', function() {
+    var f = UsedMemoryTreeNode.protectionFlagsToString;
+
+    assertEquals(f(0), '---');
+    assertEquals(f(1), '--x');
+    assertEquals(f(2), '-w-');
+    assertEquals(f(4), 'r--');
+    assertEquals(f(5), 'r-x');
+    assertEquals(f(6), 'rw-');
+    assertEquals(f(7), 'rwx');
+  });
+
+  test('checkUsedMemoryTreeLayout', function() {
+    var tree = new UsedMemoryTree();
+    // The tree is actually constructed when it's assigned a list of mmaps.
+    tree.mmaps = [];
+
+    assertNotUndefined(tree.root);
+    assertTrue(Object.keys(tree.nodes).length > 0);
+    assertTrue(tree.fields.length > 0);
+
+    // Check top-level node names.
+    assertEquals(tree.root.userFriendlyName, 'Total');
+    assertEquals(tree.root.children[0].userFriendlyName, 'Anon');
+    assertEquals(tree.root.children[1].children[0].children[1]
+        .userFriendlyName, 'JIT');
+
+    // Check that 'Other' nodes are appended to non-leaf nodes.
+    assertEquals(tree.root.children[tree.root.children.length - 1]
+        .userFriendlyName, 'Other');
+    assertEquals(tree.root.children[1].children[
+        tree.root.children[1].children.length - 1].userFriendlyName, 'Other');
+
+    // Check that children are properly linked to their parents.
+    assertUndefined(tree.root.parent);
+    assertEquals(tree.root.children[1].parent, tree.root);
+    assertEquals(tree.root.children[2].children[0].parent,
+        tree.root.children[2]);
+  });
+
+  test('checkUsedMemoryTreeSizes_zeroMmaps', function() {
+    var tree = new UsedMemoryTree();
+    tree.mmaps = [];
+
+    for (var i = 0; i < tree.fields.length; i++) {
+      assertEquals(tree.fields[i].toString(tree.root), '0.0 B');
+      assertEquals(tree.fields[i].toString(tree.root.children[0]), '0.0 B');
+      for (var key in tree.nodes) {
+        assertEquals(tree.fields[i].toString(tree.nodes[key]), '0.0 B');
+      }
+    }
+  });
+
+  test('checkUsedMemoryTreeSizes_oneMmap', function() {
+    var tree = new UsedMemoryTree();
+    tree.mmaps = [
+      {
+        'start_address': '123abc',
+        'size_in_bytes': '456def',
+        'protection_flags': 5,
+        'mapped_file': '/dev/ashmem/dalvik/rest/of/path',
+        'mapped_file_offset': '80',
+        'byte_stats': {
+          'rss': '8',
+          'pss': '9',
+          'private': 'a',
+          'shared': 'b'
+        }
+      }
+    ];
+
+    // Check that the totals were updated.
+    assertEquals(tree.fields[0].toString(tree.root), '8.0 B');
+    assertEquals(tree.fields[1].toString(tree.root), '9.0 B');
+    assertEquals(tree.fields[2].toString(tree.root), '10.0 B');
+    assertEquals(tree.fields[3].toString(tree.root), '11.0 B');
+
+    // Check that the mmap was assigned to Dalvik JIT and nothing else.
+    for (var key in tree.nodes) {
+      var node = tree.nodes[key];
+      if (!node.mmaps)
+        continue;
+      assertEquals(node.mmaps.length, key == '/ashmem/dalvik/jit/' ? 1 : 0);
+    }
+  });
+
+  test('checkUsedMemoryTreeSizes_multipleMmaps', function() {
+    var tree = new UsedMemoryTree();
+    tree.mmaps = [
+      {
+        'start_address': '200',
+        'size_in_bytes': '150',
+        'protection_flags': 6,
+        'mapped_file': '[stack:20310]',
+        'mapped_file_offset': '0',
+        'byte_stats': {
+          'rss': '50',
+          'pss': '50',
+          'private': '50',
+          'shared': '0'
+        }
+      },
+      {
+        'start_address': '350',
+        'size_in_bytes': '250',
+        'protection_flags': 6,
+        'mapped_file': '[stack:20311]',
+        'mapped_file_offset': '0',
+        'byte_stats': {
+          'rss': '100',
+          'pss': '80',
+          'private': '60',
+          'shared': '40'
+        }
+      },
+      {
+        'start_address': '5a0',
+        'size_in_bytes': 'b00',
+        'protection_flags': 4,
+        'mapped_file': '',
+        'mapped_file_offset': '0',
+        'byte_stats': {
+          'rss': '300',
+          'pss': '300',
+          'private': '300',
+          'shared': '0'
+        }
+      }
+    ];
+
+    // Check that the totals were updated.
+    assertEquals(tree.fields[0].toString(tree.root), '1.1 KiB');
+    assertEquals(tree.fields[1].toString(tree.root), '976.0 B');
+    assertEquals(tree.fields[2].toString(tree.root), '944.0 B');
+    assertEquals(tree.fields[3].toString(tree.root), '64.0 B');
+
+    // Check that the mmaps were assigned to the correct components.
+    assertEquals(tree.nodes['/anon/stack/'].mmaps.length, 2);
+    assertEquals(tree.nodes['/anon/other/'].mmaps.length, 1);
+  });
+});
+</script>


### PR DESCRIPTION
This patch adds memory tree classes for *internal memory representation* (as described in https://docs.google.com/a/chromium.org/document/d/1utHiD8aio6Vt_TMGNGJL6uIbMFG-RgxXJiBbN8Bu308/edit?usp=sharing). The diagram below describes the new class hierarchy:

![untitled drawing](https://cloud.githubusercontent.com/assets/2546601/6740232/5c5af3f2-ce76-11e4-864f-590cb64c71ca.png)

In a nutshell, a <tt>MemoryTree</tt> encapsulates both:

* the *data* (stored in a hierarchy of <tt>MemoryTreeNode</tt> objects corresponding to *rows* in a nested table) and
* its *representation* (described using <tt>MemoryTreeFieldSpecifier</tt> objects corresponding to *columns* in a nested table).