### PR TITLE
Update VSYNC highlighter to support VSYNC-app

### DIFF
--- a/trace_viewer/extras/highlighter/vsync_highlighter.html
+++ b/trace_viewer/extras/highlighter/vsync_highlighter.html
@@ -40,7 +40,11 @@ tv.exportTo('tv.e.highlighter', function() {
 
   VSyncHighlighter.VSYNC_COUNTER_PRECISIONS = {
     // Android. Seems to appear in sample systrace only.
-    'android.VSYNC': 15
+    'android.VSYNC': 15,
+    
+    // Android. Some versions have VSYNC split out into VSYNC-app and VSYNC-sf.
+    // Requires "gfx" systrace category to be enabled.
+    'android.VSYNC-app': 15,
   };
 
   VSyncHighlighter.VSYNC_SLICE_PRECISIONS = {

--- a/trace_viewer/extras/highlighter/vsync_highlighter_test.html
+++ b/trace_viewer/extras/highlighter/vsync_highlighter_test.html
@@ -18,7 +18,7 @@ tv.b.unittest.testSuite(function() {
   var VIEW_L_WORLD = 100;
   var VIEW_R_WORLD = 1000;
 
-  function buildModel(slices) {
+  function buildModel(slices, counters) {
     var model = new tv.c.TraceModel();
     var process = model.getOrCreateProcess(1);
     for (var i = 0; i < slices.length; i++) {
@@ -27,6 +27,12 @@ tv.b.unittest.testSuite(function() {
         thread.sliceGroup.pushSlice(slices[i][j]);
       }
     }
+    for (var i = 0; i < counters.length; i++) {
+      var counter = process.getOrCreateCounter(
+          counters[i].category,
+          counters[i].name);
+      counter.addSeries(counters[i].series);
+    }
     return model;
   }
 
@@ -34,9 +40,18 @@ tv.b.unittest.testSuite(function() {
     return new tv.c.trace_model.ThreadSlice('', title, 0, time, {});
   }
 
-  function testFindVSyncTimes(slices, expectedTimes) {
+  function buildCounterSeries(name, timestamps) {
+    var series = new tv.c.trace_model.CounterSeries(name, '');
+    for (var i = 0; i < timestamps.length; i++) {
+      series.addCounterSample(timestamps[i], 1);
+    }
+    return series;
+  }
+
+  function testFindVSyncTimes(slices, counters, expectedTimes) {
     assert.deepEqual(
-        expectedTimes, VSyncHighlighter.findVSyncTimes(buildModel(slices)));
+        expectedTimes,
+        VSyncHighlighter.findVSyncTimes(buildModel(slices, counters)));
   }
 
   function testGenerateStripes(times, expectedRanges) {
@@ -52,7 +67,7 @@ tv.b.unittest.testSuite(function() {
   }
 
   test('findEmpty', function() {
-    testFindVSyncTimes([], []);
+    testFindVSyncTimes([], [], []);
   });
 
   test('findNoVsync', function() {
@@ -60,11 +75,11 @@ tv.b.unittest.testSuite(function() {
         [buildSlice('MessageLoop::RunTask', 10),
          buildSlice('MessageLoop::RunTask', 20)],
         [buildSlice('MessageLoop::RunTask', 15)]
-    ], []);
+    ], [], []);
   });
 
   test('findOneVsync', function() {
-    testFindVSyncTimes([[buildSlice('vblank', 42)]], [42]);
+    testFindVSyncTimes([[buildSlice('vblank', 42)]], [], [42]);
   });
 
   test('findMultipleVsyncs', function() {
@@ -73,6 +88,21 @@ tv.b.unittest.testSuite(function() {
         [buildSlice('MessageLoop::RunTask', 3)],
         [buildSlice('MessageLoop::RunTask', 4), buildSlice('VSYNC', 5)],
         [buildSlice('VSYNC', 6), buildSlice('VSYNC', 7)]
+    ], [], [1, 5, 6, 7]);
+  });
+
+  test('findMultipleAndroidVsyncs', function() {
+    testFindVSyncTimes([
+        [buildSlice('MessageLoop::RunTask', 2)],
+        [buildSlice('MessageLoop::RunTask', 3)],
+        [buildSlice('MessageLoop::RunTask', 4)]
+    ],
+    [
+      {
+        category: 'android',
+        name: 'VSYNC-app',
+        series: buildCounterSeries('VSYNC-app', [1, 5, 6, 7])
+      }
     ], [1, 5, 6, 7]);
   });
 
@@ -82,7 +112,7 @@ tv.b.unittest.testSuite(function() {
          buildSlice('MessageLoop::RunTask', 2)],
         [buildSlice('RenderWidgetHostViewAndroid::OnVSync', 1),
          buildSlice('RenderWidgetHostViewAndroid::OnVSync', 3)]
-    ], [1, 3, 4]);
+    ], [], [1, 3, 4]);
   });
 
   test('findDifferentPrecisions', function() {
@@ -91,7 +121,7 @@ tv.b.unittest.testSuite(function() {
         [buildSlice('RenderWidgetHostViewAndroid::OnVSync', 1),
          buildSlice('vblank', 2),
          buildSlice('RenderWidgetHostViewAndroid::OnVSync', 3)]
-    ], [2]);
+    ], [], [2]);
   });
 
   test('generateInside', function() {


### PR DESCRIPTION
Later versions of Android split VSYNC into VSYNC-app and VSYNC-sf so highlighting wasn't working for those versions. Tested on Android 5.0, now see zebra stripes.