### PR TITLE
Add export options for display item lists

### DIFF
--- a/trace_viewer/base/ui/info_bar.html
+++ b/trace_viewer/base/ui/info_bar.html
@@ -23,7 +23,10 @@ found in the LICENSE file.
       padding: 0 3px 0 3px;
     }
 
-    .info-bar-hidden { display: none; }
+    :host(.info-bar-hidden) {
+      display: none;
+    }
+
     #message { flex: 1 1 auto; }
     </style>
 

--- a/trace_viewer/base/ui/info_bar_test.html
+++ b/trace_viewer/base/ui/info_bar_test.html
@@ -28,5 +28,20 @@ tv.b.unittest.testSuite(function() {
     assert.isTrue(didClick);
     this.addHTMLOutput(infoBar);
   });
+
+  test('hiding', function() {
+    var infoBar = document.createElement('tv-b-ui-info-bar');
+    infoBar.message = 'This is an info bar';
+    infoBar.visible = true;
+    this.addHTMLOutput(infoBar);
+
+    assert.equal(getComputedStyle(infoBar)['display'], 'flex');
+
+    infoBar.visible = false;
+    assert.equal(getComputedStyle(infoBar)['display'], 'none');
+
+    infoBar.visible = true;
+    assert.equal(getComputedStyle(infoBar)['display'], 'flex');
+  });
 });
 </script>

--- a/trace_viewer/extras/cc/display_item_debugger.html
+++ b/trace_viewer/extras/cc/display_item_debugger.html
@@ -109,12 +109,12 @@ found in the LICENSE file.
         <span class='title'>Display Item List</span>
         <span class='size'></span>
         <div class='export'>
-          <input class='skpfilename' type='text' value='skpicture.skp' />
-          <button class='skpexport'>Export SkPicture</button>
+          <input class='dlfilename' type='text' value='displayitemlist.json' />
+          <button class='dlexport'>Export display item list</button>
         </div>
         <div class='export'>
-          <input class='dlfilename' type='text' value='displayitemlist.json' />
-          <button class='dlexport'>Export Display Items</button>
+          <input class='skpfilename' type='text' value='skpicture.skp' />
+          <button class='skpexport'>Export list as SkPicture</button>
         </div>
       </header>
     </display-item-info>
@@ -166,15 +166,15 @@ tv.exportTo('tv.e.cc', function() {
           this.onDisplayItemListSelection_.bind(this));
       this.displayItemInfo_.appendChild(this.displayItemListView_);
 
-      this.skpFilename_ = this.querySelector('.skpfilename');
-      this.skpExportButton_ = this.querySelector('.skpexport');
-      this.skpExportButton_.addEventListener(
-          'click', this.onExportSkPictureClicked_.bind(this));
-
       this.displayListFilename_ = this.querySelector('.dlfilename');
       this.displayListExportButton_ = this.querySelector('.dlexport');
       this.displayListExportButton_.addEventListener(
           'click', this.onExportDisplayListClicked_.bind(this));
+
+      this.skpFilename_ = this.querySelector('.skpfilename');
+      this.skpExportButton_ = this.querySelector('.skpexport');
+      this.skpExportButton_.addEventListener(
+          'click', this.onExportSkPictureClicked_.bind(this));
 
       var leftPanel = this.querySelector('left-panel');
 
@@ -452,14 +452,14 @@ tv.exportTo('tv.e.cc', function() {
       link.dispatchEvent(event);
     },
 
-    onExportSkPictureClicked_: function() {
-      var rawData = atob(this.picture_.getBase64SkpData());
-      this.saveFile_(this.skpFilename_.value, rawData);
-    },
-
     onExportDisplayListClicked_: function() {
       var rawData = JSON.stringify(this.displayItemList_.items);
       this.saveFile_(this.displayListFilename_.value, rawData);
+    },
+
+    onExportSkPictureClicked_: function() {
+      var rawData = atob(this.picture_.getBase64SkpData());
+      this.saveFile_(this.skpFilename_.value, rawData);
     }
   };
 

--- a/trace_viewer/extras/cc/display_item_debugger.html
+++ b/trace_viewer/extras/cc/display_item_debugger.html
@@ -41,6 +41,10 @@ found in the LICENSE file.
     margin-right: 5px;
   }
 
+  * /deep/ display-item-debugger > left-panel > display-item-info .export {
+    margin: 5px;
+  }
+
   * /deep/ display-item-debugger > x-drag-handle {
     -webkit-flex: 0 0 auto;
   }
@@ -104,6 +108,14 @@ found in the LICENSE file.
       <header>
         <span class='title'>Display Item List</span>
         <span class='size'></span>
+        <div class='export'>
+          <input class='skpfilename' type='text' value='skpicture.skp' />
+          <button class='skpexport'>Export SkPicture</button>
+        </div>
+        <div class='export'>
+          <input class='dlfilename' type='text' value='displayitemlist.json' />
+          <button class='dlexport'>Export Display Items</button>
+        </div>
       </header>
     </display-item-info>
   </left-panel>
@@ -153,6 +165,16 @@ tv.exportTo('tv.e.cc', function() {
       this.displayItemListView_.addEventListener('selection-changed',
           this.onDisplayItemListSelection_.bind(this));
       this.displayItemInfo_.appendChild(this.displayItemListView_);
+
+      this.skpFilename_ = this.querySelector('.skpfilename');
+      this.skpExportButton_ = this.querySelector('.skpexport');
+      this.skpExportButton_.addEventListener(
+          'click', this.onExportSkPictureClicked_.bind(this));
+
+      this.displayListFilename_ = this.querySelector('.dlfilename');
+      this.displayListExportButton_ = this.querySelector('.dlexport');
+      this.displayListExportButton_.addEventListener(
+          'click', this.onExportDisplayListClicked_.bind(this));
 
       var leftPanel = this.querySelector('left-panel');
 
@@ -402,6 +424,42 @@ tv.exportTo('tv.e.cc', function() {
         x: e.clientX - this.rasterArea_.offsetLeft,
         y: e.clientY - this.rasterArea_.offsetTop
       };
+    },
+
+    saveFile_: function(filename, rawData) {
+      if (!rawData)
+        return;
+
+      // Convert this String into an Uint8Array
+      var length = rawData.length;
+      var arrayBuffer = new ArrayBuffer(length);
+      var uint8Array = new Uint8Array(arrayBuffer);
+      for (var c = 0; c < length; c++)
+        uint8Array[c] = rawData.charCodeAt(c);
+
+      // Create a blob URL from the binary array.
+      var blob = new Blob([uint8Array], {type: 'application/octet-binary'});
+      var blobUrl = window.URL.createObjectURL(blob);
+
+      // Create a link and click on it.
+      var link = document.createElementNS('http://www.w3.org/1999/xhtml', 'a');
+      link.href = blobUrl;
+      link.download = filename;
+      var event = document.createEvent('MouseEvents');
+      event.initMouseEvent(
+          'click', true, false, window, 0, 0, 0, 0, 0,
+          false, false, false, false, 0, null);
+      link.dispatchEvent(event);
+    },
+
+    onExportSkPictureClicked_: function() {
+      var rawData = atob(this.picture_.getBase64SkpData());
+      this.saveFile_(this.skpFilename_.value, rawData);
+    },
+
+    onExportDisplayListClicked_: function() {
+      var rawData = JSON.stringify(this.displayItemList_.items);
+      this.saveFile_(this.displayListFilename_.value, rawData);
     }
   };
 

--- a/trace_viewer/extras/cc/display_item_debugger_test.html
+++ b/trace_viewer/extras/cc/display_item_debugger_test.html
@@ -87,5 +87,44 @@ tv.b.unittest.testSuite(function() {
 
     dbg.style.border = '1px solid black';
   });
+
+  test('export', function() {
+    var displayItemList = new tv.e.cc.DisplayItemListSnapshot(
+      {id: '31415'},
+      10,
+      {
+        'params': {
+          'layer_rect': [-15, -15, 46, 833],
+          'items': [
+            'BeginClipDisplayItem',
+            'EndClipDisplayItem'
+          ]
+        },
+        'skp64': 'c2twaWN0dXJl'});
+    displayItemList.preInitialize();
+    displayItemList.initialize();
+
+    var dbg = new tv.e.cc.DisplayItemDebugger();
+    this.addHTMLOutput(dbg);
+    dbg.displayItemList = displayItemList;
+
+    var onSaveDisplayListCalled = false;
+    dbg.saveFile_ = function(filename, rawData) {
+      onSaveDisplayListCalled = true;
+      assert.equal(filename, 'displayitemlist.json');
+      assert.equal(rawData, '["BeginClipDisplayItem","EndClipDisplayItem"]');
+    };
+    dbg.onExportDisplayListClicked_();
+    assert(onSaveDisplayListCalled);
+
+    var onSaveSkPictureCalled = false;
+    dbg.saveFile_ = function(filename, rawData) {
+      onSaveSkPictureCalled = true;
+      assert.equal(filename, 'skpicture.skp');
+      assert.equal(rawData, 'skpicture');
+    };
+    dbg.onExportSkPictureClicked_();
+    assert(onSaveSkPictureCalled);
+  });
 });
 </script>


### PR DESCRIPTION
This patch adds two export options to the display item debugger. These
options are for exporting the display list as a json object and
exporting the entire list as a singe skp. As we get closer to launch,
this will help us debug slimming paint issues (e.g., crbug.com/485597).

A preview of this feature is at:
http://philiprogers.com/exportdisplayitems2.png