### PR TITLE
Fix style so info bar is properly hidden

### DIFF
--- a/trace_viewer/base/ui/info_bar.html
+++ b/trace_viewer/base/ui/info_bar.html
@@ -23,7 +23,10 @@ found in the LICENSE file.
       padding: 0 3px 0 3px;
     }
 
-    .info-bar-hidden { display: none; }
+    :host(.info-bar-hidden) {
+      display: none;
+    }
+
     #message { flex: 1 1 auto; }
     </style>
 

--- a/trace_viewer/base/ui/info_bar_test.html
+++ b/trace_viewer/base/ui/info_bar_test.html
@@ -28,5 +28,20 @@ tv.b.unittest.testSuite(function() {
     assert.isTrue(didClick);
     this.addHTMLOutput(infoBar);
   });
+
+  test('hiding', function() {
+    var infoBar = document.createElement('tv-b-ui-info-bar');
+    infoBar.message = 'This is an info bar';
+    infoBar.visible = true;
+    this.addHTMLOutput(infoBar);
+
+    assert.equal(getComputedStyle(infoBar)['display'], 'flex');
+
+    infoBar.visible = false;
+    assert.equal(getComputedStyle(infoBar)['display'], 'none');
+
+    infoBar.visible = true;
+    assert.equal(getComputedStyle(infoBar)['display'], 'flex');
+  });
 });
 </script>


### PR DESCRIPTION
The info bar's hidden style was not properly matching which caused
empty yellow butter bars on several views (layer tree, picture
debugger, etc.) This patch fixes the style so the info bar can be
hidden.

R=nduca@chromium.org

Review URL: https://codereview.appspot.com/233550043